### PR TITLE
Add API route to update outing status via cron

### DIFF
--- a/.github/workflows/outing-status-cron.yml
+++ b/.github/workflows/outing-status-cron.yml
@@ -1,0 +1,55 @@
+name: Update Outing Status
+
+on:
+  schedule:
+    - cron: "*/10 * * * *" # every 10 minutes
+  # Allow manual runs from the Actions UI for testing
+  workflow_dispatch: {}
+
+jobs:
+  update-status:
+    # Prevent overlapping runs and limit concurrency
+    concurrency:
+      group: update-outing-status
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    # Grant the workflow the least privilege: it doesn't need to read repository contents
+    permissions: {}
+    # Use a protected GitHub Environment to host the secret and apply deployment protections.
+    # Create an environment named `outing-update` in the repository settings and add
+    # the secret `UPDATE_OUTING_STATUS_SECRET` there. The job will require environment
+    # approval/policies if configured.
+    environment:
+      name: outing-update
+    env:
+      TOKEN: ${{ secrets.UPDATE_OUTING_STATUS_SECRET }}
+    steps:
+      - name: Trigger Outing Status Update
+        run: |
+          set -euo pipefail
+          URL="https://sabc-woad.vercel.app/api/update-outing-status"
+
+          # Send request and capture status and a short response body (first 8KB)
+          RESPONSE_FILE=$(mktemp)
+          HTTP_STATUS=$(curl -sS -w "%{http_code}" -o "$RESPONSE_FILE" \
+            -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            "$URL") || true
+
+          # Read a short snippet of the response for logs (avoid huge bodies)
+          RESPONSE_SNIPPET=$(head -c 8192 "$RESPONSE_FILE" | tr -d '\r' || true)
+          rm -f "$RESPONSE_FILE"
+
+          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+            echo "[outing-status-cron] Success: HTTP $HTTP_STATUS"
+            if [ -n "$RESPONSE_SNIPPET" ]; then
+              echo "[outing-status-cron] Response: ${RESPONSE_SNIPPET}"
+            fi
+          else
+            echo "[outing-status-cron] Failure: HTTP $HTTP_STATUS"
+            if [ -n "$RESPONSE_SNIPPET" ]; then
+              echo "[outing-status-cron] Response (truncated): ${RESPONSE_SNIPPET}"
+            fi
+            exit 1
+          fi

--- a/src/app/api/update-outing-status/route.ts
+++ b/src/app/api/update-outing-status/route.ts
@@ -1,0 +1,77 @@
+// src/app/api/update-outing-status/route.ts
+import { NextResponse } from 'next/server';
+import { Client } from '@notionhq/client';
+
+const notion = new Client({ auth: process.env.NOTION_TOKEN });
+const OUTINGS_DB_ID = process.env.NOTION_OUTINGS_DB_ID;
+const FLAG_STATUS_API = 'https://ourcs.co.uk/api/flags/status/isis/';
+
+// Map flag status to Notion outing status
+const flagToOutingStatus: Record<string, string> = {
+    'Red': 'Cancelled',
+    'Black': 'Cancelled',
+};
+
+export async function POST() {
+  if (!OUTINGS_DB_ID) {
+    return NextResponse.json({ error: 'Missing Notion outings database ID' }, { status: 500 });
+  }
+
+  // 1. Fetch flag status
+  const flagRes = await fetch(FLAG_STATUS_API);
+  if (!flagRes.ok) {
+    return NextResponse.json({ error: 'Failed to fetch flag status' }, { status: 500 });
+  }
+  const flagData = await flagRes.json();
+  const flagStatus = flagData.status;
+  console.log(`[LIVE MODE] Fetched flag status: ${flagStatus}`);
+  // Only update if flag is Red or Black
+  if (flagStatus !== 'Red' && flagStatus !== 'Black') {
+    console.log(`[LIVE MODE] No update performed. Flag status is '${flagStatus}'.`);
+    return NextResponse.json({ updated: [], message: `No update performed. Flag status is '${flagStatus}'.` });
+  }
+  const newOutingStatus = flagToOutingStatus[flagStatus];
+  console.log(`[LIVE MODE] Updating outings to status: ${newOutingStatus}`);
+
+  // 2. Query Notion for upcoming water outings
+  const now = new Date().toISOString();
+  const response = await notion.databases.query({
+    database_id: OUTINGS_DB_ID,
+    filter: {
+      and: [
+        {
+          property: 'Type',
+          select: { equals: 'Water Outing' },
+        },
+        {
+          property: 'Start Date/Time',
+          date: { after: now },
+        },
+      ],
+    },
+    page_size: 100,
+  });
+
+  // 3. Update status for each outing
+  const updated: string[] = [];
+  for (const page of response.results) {
+    if ('id' in page) {
+      try {
+        await notion.pages.update({
+          page_id: page.id,
+          properties: {
+            Status: {
+              status: { name: newOutingStatus },
+            },
+          },
+        });
+        updated.push(page.id);
+        console.log(`[LIVE MODE] Updated outing: ${page.id}`);
+      } catch (err) {
+        console.error(`[LIVE MODE] Failed to update outing: ${page.id}`, err);
+      }
+    }
+  }
+
+  return NextResponse.json({ updated, newOutingStatus });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "cron": [
+    {
+      "path": "/api/update-outing-status",
+      "schedule": "*/10 * * * *"
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
-  "cron": [
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
     {
       "path": "/api/update-outing-status",
       "schedule": "*/10 * * * *"

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,3 @@
 {
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "crons": [
-    {
-      "path": "/api/update-outing-status",
-      "schedule": "*/10 * * * *"
-    }
-  ]
+  "$schema": "https://openapi.vercel.sh/vercel.json"
 }


### PR DESCRIPTION
Introduces a new API endpoint that updates Notion outing statuses based on flag status fetched from an external API. Also adds a Vercel cron configuration to trigger this endpoint every 10 minutes.