### PR TITLE
Add Home, Coxing, and Events pages and icons

### DIFF
--- a/src/app/(app shell)/schedule/CalendarHeader.tsx
+++ b/src/app/(app shell)/schedule/CalendarHeader.tsx
@@ -74,7 +74,7 @@ export default function CalendarHeader({
       style={{ gap: '40px' }}
     >
   {/* Title */}
-  <h1 className="font-bold" style={{ fontSize: '32px', marginTop: '5.5px' }}>Club Schedule</h1>
+  <h1 className="font-bold" style={{ fontSize: '32px'}}>Club Schedule</h1>
 
       {/* Week Display and Filter Row */}
       <div

--- a/src/app/(app shell)/sidebar/CoxingIcon.tsx
+++ b/src/app/(app shell)/sidebar/CoxingIcon.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export function CoxingIcon(props: React.SVGProps<SVGSVGElement> & { stroke?: string }) {
+  const strokeColor = props.stroke || "#425466";
+  return (
+    <svg width={20} height={20} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path fillRule="evenodd" clipRule="evenodd" d="M2.50185 12.0003C2.49906 13.2299 2.44419 14.9071 3.20494 15.534C3.91453 16.1188 4.41395 15.9682 5.70945 16.0632C7.00587 16.1592 9.74195 19.9701 11.8512 18.7647C12.9393 17.909 13.0202 16.1152 13.0202 12.0003C13.0202 7.88528 12.9393 6.09147 11.8512 5.23583C9.74195 4.0295 7.00587 7.84133 5.70945 7.9373C4.41395 8.03237 3.91453 7.88169 3.20494 8.46647C2.44419 9.0934 2.49906 10.7706 2.50185 12.0003Z" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M19.5842 5.90411C22.1343 9.57513 22.1427 14.4175 19.5842 18.0957" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M17.0813 8.31451C18.3926 10.6052 18.3926 13.4026 17.0813 15.6861" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+}

--- a/src/app/(app shell)/sidebar/EventsIcon.tsx
+++ b/src/app/(app shell)/sidebar/EventsIcon.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+export function EventsIcon(props: React.SVGProps<SVGSVGElement> & { stroke?: string }) {
+  const strokeColor = props.stroke || "#425466";
+  return (
+    <svg width={20} height={20} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M3.09253 9.40439H20.9165" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M16.442 13.3098H16.4512" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M12.0047 13.3098H12.014" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M7.55793 13.3098H7.5672" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M16.442 17.1963H16.4512" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M12.0047 17.1963H12.014" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M7.55793 17.1963H7.5672" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M16.0438 2.00012V5.2909" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M7.9654 2.00012V5.2909" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M16.2383 3.57932H7.77096C4.83427 3.57932 3 5.21525 3 8.22234V17.272C3 20.3264 4.83427 22.0001 7.77096 22.0001H16.229C19.175 22.0001 21 20.3547 21 17.3476V8.22234C21.0092 5.21525 19.1842 3.57932 16.2383 3.57932Z" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+}

--- a/src/app/(app shell)/sidebar/HomeIcon.tsx
+++ b/src/app/(app shell)/sidebar/HomeIcon.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export function HomeIcon(props: React.SVGProps<SVGSVGElement> & { stroke?: string }) {
+  const strokeColor = props.stroke || "#425466";
+  return (
+    <svg width={20} height={20} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M9.15722 20.7715V17.7048C9.1572 16.9248 9.79312 16.2909 10.581 16.2857H13.4671C14.2587 16.2857 14.9005 16.9211 14.9005 17.7048V17.7048V20.781C14.9003 21.4433 15.4343 21.9846 16.103 22.0001H18.0271C19.9451 22.0001 21.5 20.4608 21.5 18.562V18.562V9.83796C21.4898 9.09095 21.1355 8.38947 20.538 7.93315L13.9577 2.68542C12.8049 1.77169 11.1662 1.77169 10.0134 2.68542L3.46203 7.94268C2.86226 8.39714 2.50739 9.09979 2.5 9.84748V18.562C2.5 20.4608 4.05488 22.0001 5.97291 22.0001H7.89696C8.58235 22.0001 9.13797 21.4501 9.13797 20.7715V20.7715" stroke={strokeColor} strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+}

--- a/src/app/(app shell)/sidebar/Sidebar.tsx
+++ b/src/app/(app shell)/sidebar/Sidebar.tsx
@@ -6,6 +6,9 @@ import SwimIcon from "./SwimIcon";
 import PersonIcon from "./PersonIcon";
 import { MoreSquareIcon } from "./MoreSquareIcon";
 import { SendIcon } from "./SendIcon";
+import { HomeIcon } from "./HomeIcon";
+import { CoxingIcon } from "./CoxingIcon";
+import { EventsIcon } from "./EventsIcon";
 import { usePathname, useRouter } from "next/navigation";
 import Box from "@/components/ui/Box";
 import ActionButton from "@/components/ui/ActionButton";
@@ -51,7 +54,7 @@ export default function Sidebar() {
         shadow
       "
   p={32}
-  style={{ gap: 34.5, borderRight: '1px solid #DFE5F1', backgroundColor: '#ffffff' }}
+  style={{ gap: 40, borderRight: '1px solid #DFE5F1', backgroundColor: '#ffffff' }}
     >
       {/* Brand */}
       <Box>
@@ -64,8 +67,8 @@ export default function Sidebar() {
           <Image
             src="/sabc-logo.png"
             alt="SABC Logo"
-            width={50}
-            height={50}
+            width={40}
+            height={40}
           />
           <div style={{
             color: '#27272e',
@@ -107,30 +110,48 @@ export default function Sidebar() {
           }}
         >
           <NavItem
+            href="/home"
+            label="Home"
+            icon={<HomeIcon stroke={pathname?.startsWith("/home") ? "#fff" : "#425466"} />}
+            active={pathname?.startsWith("/home")}
+          />
+          <NavItem
             href="/schedule"
             label="Schedule"
             icon={<ClockIcon stroke="#425466" />}
             active={!!isSchedule}
           />
           <NavItem
+            href="/coxing"
+            label="Coxing"
+            icon={<CoxingIcon stroke={pathname?.startsWith("/coxing") ? "#fff" : "#425466"} />}
+            active={pathname?.startsWith("/coxing")}
+          />
+          <NavItem
             href="/flag-status"
-            label="Isis Flag"
+            label="Flag Status"
             icon={<FlagIcon stroke="#425466" />}
             active={!!isFlagStatus}
           />
           <NavItem
             href="/swim-tests"
-            label="Swim Tests"
+            label="OURC Tests"
             icon={<SwimIcon stroke="#425466" />}
             active={pathname?.startsWith("/swim-tests")}
           />
+          <NavItem
+            href="/events"
+            label="Events"
+            icon={<EventsIcon stroke={pathname?.startsWith("/events") ? "#fff" : "#425466"} />}
+            active={pathname?.startsWith("/events")}
+          />
+          <div style={{ width: '100%', height: '1px', background: '#DFE5F1', margin: '8px 0' }} />
           <NavItem
             href="/membership"
             label="Members"
             icon={<PersonIcon stroke="#425466" />}
             active={pathname?.startsWith("/membership")}
           />
-          <div style={{ width: '100%', height: '1px', background: '#DFE5F1', margin: '8px 0' }} />
           <NavItem
             href="/feedback"
             label="Feedback"

--- a/src/app/coxing/page.tsx
+++ b/src/app/coxing/page.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function CoxingPage() {
+  return (
+   <div className="container mx-auto p-2">
+  <h1 className="font-bold" style={{ fontSize: '32px' }}>Coxing</h1>
+      <div className="w-full"></div>
+    </div>
+  );
+}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function EventsPage() {
+  return (
+   <div className="container mx-auto p-2">
+  <h1 className="font-bold" style={{ fontSize: '32px' }}>Events</h1>
+      <div className="w-full"></div>
+    </div>
+  );
+}

--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -4,7 +4,7 @@
 export default function FeedbackPage() {
   return (
     <div className="container mx-auto p-2">
-        <h1 className="font-bold" style={{ fontSize: '32px', marginTop: '5.5px' }}>Feedback Form</h1>
+  <h1 className="font-bold" style={{ fontSize: '32px' }}>Feedback Form</h1>
       <div className="w-full">
               <iframe
                   src="https://stantonysboatclub.notion.site/ebd/24e80040a8fa8035bec2c5387a981512"

--- a/src/app/flag-status/page.tsx
+++ b/src/app/flag-status/page.tsx
@@ -26,7 +26,7 @@ export default async function FlagStatusPage() {
 
   return (
     <>
-        <h1 className="font-bold" style={{ fontSize: '32px', marginTop: '5.5px' }}>Flag Status</h1>
+  <h1 className="font-bold" style={{ fontSize: '32px' }}>Flag Status</h1>
       <main
         style={{
           display: 'flex',

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function HomePage() {
+  return (
+   <div className="container mx-auto p-2">
+  <h1 className="font-bold" style={{ fontSize: '32px' }}>Home</h1>
+      <div className="w-full"></div>
+    </div>
+  );
+}

--- a/src/app/membership/page.tsx
+++ b/src/app/membership/page.tsx
@@ -3,7 +3,7 @@ import React from "react";
 export default function MembershipPage() {
   return (
     <div className="p-8">
-      <h1 className="font-bold" style={{ fontSize: '32px', marginTop: '5.5px' }}>Membership Sign Up</h1>
+  <h1 className="font-bold" style={{ fontSize: '32px' }}>Membership Sign Up</h1>
       <iframe
         src="https://stantonysboatclub.notion.site/ebd/23d80040a8fa80b6a200eacaf389bedf"
         width="100%"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,6 @@
 import { redirect } from 'next/navigation';
 
 export default function HomePage() {
-  redirect('/schedule');
+  redirect('/home');
   return null;
 }

--- a/src/app/swim-tests/page.tsx
+++ b/src/app/swim-tests/page.tsx
@@ -3,7 +3,7 @@ import React from "react";
 export default function SwimTestsPage() {
   return (
     <div className="p-8">
-      <h1 className="font-bold" style={{ fontSize: '32px', marginTop: '5.5px' }}>Swim Test Sign Up</h1>
+  <h1 className="font-bold" style={{ fontSize: '32px' }}>Swim Test Sign Up</h1>
       <iframe
         src="https://stantonysboatclub.notion.site/ebd/23d80040a8fa80ff915dd3870dae20f2"
         width="100%"


### PR DESCRIPTION
Introduces new Home, Coxing, and Events pages with corresponding SVG icons and updates the sidebar navigation to include these sections. Also standardizes header styles across multiple pages and updates the default redirect to /home. Sidebar layout and labels are adjusted for consistency.