### PR TITLE
Add Notion events API and carousel UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@vercel/speed-insights": "^1.2.0",
         "clsx": "^2.1.1",
         "dotenv": "^17.2.1",
+        "embla-carousel-react": "^8.6.0",
         "next": "15.4.5",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -2969,6 +2970,34 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
       }
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@vercel/speed-insights": "^1.2.0",
     "clsx": "^2.1.1",
     "dotenv": "^17.2.1",
+    "embla-carousel-react": "^8.6.0",
     "next": "15.4.5",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/src/app/api/get-events/route.ts
+++ b/src/app/api/get-events/route.ts
@@ -1,0 +1,154 @@
+// src/app/api/get-events/route.ts
+import { NextResponse } from 'next/server'
+import { Client } from '@notionhq/client'
+
+const notion = new Client({
+  auth: process.env.NOTION_TOKEN,
+  notionVersion: '2025-09-03',
+})
+
+const EVENTS_DB_ID = '27a80040-a8fa-804a-9f8b-d536dcc548a7'
+
+export async function GET() {
+  try {
+    console.log('🔍 Fetching events from Notion...')
+
+    // Validate environment variables
+    if (!process.env.NOTION_TOKEN) {
+      console.error('❌ NOTION_TOKEN is not set')
+      return NextResponse.json(
+        { error: 'Missing Notion token configuration' },
+        { status: 500 }
+      )
+    }
+
+    console.log(`🗄️ Using Events database: ${EVENTS_DB_ID}`)
+
+    // First get the database to find data sources
+    const databaseResponse = await notion.request({
+      method: 'get',
+      path: `databases/${EVENTS_DB_ID}`,
+    }) as { data_sources?: { id: string }[] }
+
+    if (!databaseResponse.data_sources || databaseResponse.data_sources.length === 0) {
+      console.error('❌ No data sources found for events database')
+      return NextResponse.json(
+        { error: 'No data sources found for events database' },
+        { status: 500 }
+      )
+    }
+
+    const dataSourceId = databaseResponse.data_sources[0].id
+    console.log(`📊 Using data source: ${dataSourceId}`)
+
+    // Query the Events database
+    const queryResponse = await notion.request({
+      method: 'post',
+      path: `data_sources/${dataSourceId}/query`,
+      body: {
+        sorts: [
+          {
+            property: 'Date',
+            direction: 'ascending'
+          }
+        ],
+        page_size: 50, // Limit to 50 events for performance
+      },
+    }) as any
+
+    console.log(`✅ Retrieved ${queryResponse.results?.length || 0} events`)
+
+    // Transform the Notion results to our Event format
+    const events = queryResponse.results?.map((page: any) => transformNotionPageToEvent(page)) || []
+
+    return NextResponse.json({
+      success: true,
+      events,
+      count: events.length
+    })
+
+  } catch (error) {
+    console.error('❌ Error fetching events:', error)
+    return NextResponse.json(
+      {
+        error: 'Failed to fetch events',
+        details: error instanceof Error ? error.message : 'Unknown error'
+      },
+      { status: 500 }
+    )
+  }
+}
+
+function transformNotionPageToEvent(page: any): any {
+  const properties = page.properties || {}
+
+  // Extract title from "Event" property (title type)
+  const title = properties.Event?.title?.[0]?.text?.content || 'Untitled Event'
+
+  // Extract description from "Description" property (text type)
+  const description = properties.Description?.rich_text?.[0]?.text?.content || ''
+
+  // Extract date from "Date" property (date type)
+  let date = ''
+  let time = ''
+  let dateTime = ''
+
+  if (properties.Date?.date) {
+    const notionDate = properties.Date.date
+    dateTime = notionDate.start
+
+    // Format date for display
+    const dateObj = new Date(notionDate.start)
+    date = dateObj.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    })
+
+    // Check if time is included
+    if (notionDate.start.includes('T')) {
+      const startObj = dateObj
+      const startTime = startObj.toLocaleTimeString('en-US', {
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true
+      })
+
+      if (notionDate.end) {
+        const endObj = new Date(notionDate.end)
+        const endTime = endObj.toLocaleTimeString('en-US', {
+          hour: 'numeric',
+          minute: '2-digit',
+          hour12: true
+        })
+
+        // Show both start and end times
+        time = `${startTime} — ${endTime}`
+      } else {
+        time = startTime
+      }
+    }
+  }
+
+  // Extract image from "Files & media" property (file type)
+  let imageUrl = ''
+  const filesMedia = properties['Files & media']?.files
+  if (filesMedia && filesMedia.length > 0) {
+    const firstFile = filesMedia[0]
+    if (firstFile.type === 'file') {
+      imageUrl = firstFile.file?.url || ''
+    } else if (firstFile.type === 'external') {
+      imageUrl = firstFile.external?.url || ''
+    }
+  }
+
+  return {
+    id: page.id,
+    title,
+    description,
+    date,
+    time: time || undefined,
+    dateTime,
+    imageUrl: imageUrl || undefined,
+  }
+}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,10 +1,167 @@
+ 'use client'
+
 import React from 'react';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  type CarouselApi,
+} from '@/components/ui/carousel';
+import { LeftArrow } from '@/components/icons/LeftArrow';
+import { RightArrow } from '@/components/icons/RightArrow';
+import { EventCard } from '@/components/EventCard';
+import { useEvents } from '@/hooks/useEvents';
 
 export default function EventsPage() {
+  const { events, loading, error, refetch } = useEvents()
+  const [carouselApi, setCarouselApi] = React.useState<CarouselApi | null>(null)
+  const containerRef = React.useRef<HTMLDivElement | null>(null)
+
+  React.useEffect(() => {
+    if (!containerRef.current) return
+
+    const getCards = () => Array.from(containerRef.current!.querySelectorAll<HTMLElement>('.event-card'))
+
+    const resize = () => {
+      const cards = getCards()
+      if (!cards || cards.length === 0) return
+      const heights = cards.map((n) => n.offsetHeight)
+      const max = Math.max(...heights, 0)
+      cards.forEach((n) => {
+        n.style.minHeight = `${max}px`
+      })
+    }
+
+    // initial measurement
+    resize()
+
+    let ro: ResizeObserver | null = null
+    if (typeof window !== 'undefined' && (window as any).ResizeObserver) {
+      ro = new (window as any).ResizeObserver(resize)
+      const cards = getCards()
+      cards.forEach((n) => ro!.observe(n))
+      // also observe images inside cards (they may load later)
+      cards.forEach((n) => {
+        Array.from(n.querySelectorAll('img')).forEach((img) => ro!.observe(img))
+      })
+    } else {
+      if (typeof window !== 'undefined') {
+        (window as any).addEventListener('resize', resize)
+      }
+      // fallback: listen for image load
+      const imgs = containerRef.current.querySelectorAll('img')
+      imgs.forEach((img) => (img as HTMLImageElement).addEventListener('load', resize))
+    }
+
+    return () => {
+      if (ro) {
+        const cards = getCards()
+        cards.forEach((n) => ro!.unobserve(n))
+      } else {
+        if (typeof window !== 'undefined') {
+          (window as any).removeEventListener('resize', resize)
+        }
+        const imgs = containerRef.current?.querySelectorAll('img') || []
+        imgs.forEach((img) => (img as HTMLImageElement).removeEventListener('load', resize))
+      }
+    }
+  }, [events])
+
+  if (loading) {
+    return (
+      <main className="flex flex-col">
+        <h1 className="text-2xl font-bold" style={{ marginBottom: 40 }}>Events</h1>
+        <div className="text-center py-12 flex items-center justify-center" style={{ width: '100%', minHeight: '200px' }}>
+          <p className="text-muted-foreground mb-2">Loading events...</p>
+        </div>
+      </main>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto p-6">
+        <h1 className="font-bold text-4xl" style={{ marginBottom: 40 }}>Events</h1>
+        <div className="flex items-center justify-center py-12">
+          <div className="text-center">
+            <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+              <p className="font-semibold">Error loading events</p>
+              <p className="text-sm">{error}</p>
+            </div>
+            <button
+              onClick={refetch}
+              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded transition-colors"
+            >
+              Try Again
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (events.length === 0) {
+    return (
+        <main className="flex flex-col">
+          <h1 className="text-2xl font-bold" style={{ marginBottom: 100 }}>Events</h1>
+          <div className="text-center py-12 flex items-center justify-center" style={{ width: '100%', minHeight: '200px' }}>
+            <p className="text-muted-foreground mb-2">No upcoming events</p>
+          </div>
+        </main>
+    )
+  }
+
   return (
-   <div className="container mx-auto p-2">
-  <h1 className="font-bold" style={{ fontSize: '32px' }}>Events</h1>
-      <div className="w-full"></div>
-    </div>
+    <main className="flex flex-col bg-transparent">
+      <h1 className="text-2xl font-bold flex-shrink-0" style={{ marginBottom: 100 }}>Events</h1>
+
+      <div style={{ width: '100%', overflow: 'visible' }}>
+          {error && <div>Error loading events</div>}
+          {!loading && !error && events && events.length === 0 && (
+            <div>No upcoming events</div>
+          )}
+
+          {!loading && !error && events && events.length > 0 && (
+            <div ref={containerRef} style={{ width: 968, margin: '0 auto', position: 'relative', padding: '24px 24px', boxSizing: 'content-box', overflow: 'visible' }}>
+              <Carousel
+                className="w-full overflow-visible"
+                opts={{ align: 'center', containScroll: 'trimSnaps' }}
+                setApi={setCarouselApi}
+              >
+                <CarouselContent className="-ml-4">
+                  {events.map((ev) => (
+                    <CarouselItem
+                      key={ev.id}
+                      className="pl-4 basis-1/3"
+                    >
+                      <EventCard event={ev} className="event-card" />
+                    </CarouselItem>
+                  ))}
+                </CarouselContent>
+              </Carousel>
+
+              <div className="flex items-center justify-center" role="group" aria-label="carousel controls" style={{ marginTop: '32px', gap: '8px' }}>
+                <button
+                  onClick={() => carouselApi?.scrollPrev()}
+                  aria-label="Previous slide"
+                  className="flex items-center justify-center bg-[rgba(246,247,249,0.60)] hover:bg-[rgba(125,141,166,0.20)] transition-colors border-0"
+                  style={{ width: 36, height: 36, padding: 0, borderRadius: '10px', cursor: 'pointer' }}
+                >
+                  <LeftArrow />
+                </button>
+
+                <button
+                  onClick={() => carouselApi?.scrollNext()}
+                  aria-label="Next slide"
+                  className="flex items-center justify-center bg-[rgba(246,247,249,0.60)] hover:bg-[rgba(125,141,166,0.20)] transition-colors border-0"
+                  style={{ width: 36, height: 36, padding: 0, borderRadius: '10px', cursor: 'pointer' }}
+                >
+                  <RightArrow />
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+    </main>
   );
 }

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,0 +1,86 @@
+// src/components/EventCard.tsx
+import React from 'react';
+import { cn } from '@/lib/classnames';
+
+export interface Event {
+  id: string;
+  title: string; // from "Event" property (title)
+  description: string; // from "Description" property (text)
+  date: string; // from "Date" property (date) - formatted display date
+  time?: string; // from "Date" property (date with time) - formatted display time
+  dateTime?: string; // ISO string for the actual date/time value
+  imageUrl?: string; // from "Files & media" property (file)
+}
+
+export interface EventCardProps {
+  event: Event;
+  className?: string;
+}
+
+export function EventCard({ event, className }: EventCardProps) {
+  return (
+    <div
+      className={cn("flex flex-col items-start", className)}
+      style={{
+        width: '280px',
+        padding: '16px',
+        gap: '16px',
+        borderRadius: '20px',
+        background: '#FFF',
+        boxShadow: '0 9px 44px 0 rgba(174, 174, 174, 0.20)',
+        boxSizing: 'border-box',
+        maxHeight: '100%',
+        overflow: 'hidden',
+      }}
+    >
+      {event.imageUrl && (
+        <img
+          src={event.imageUrl}
+          alt={event.title}
+          style={{
+            height: '250px',
+            alignSelf: 'stretch',
+            borderRadius: '10px',
+            objectFit: 'cover',
+            display: 'block',
+          }}
+        />
+      )}
+
+      <div className="flex flex-col" style={{ gap: '16px', alignSelf: 'stretch', minHeight: 0 }}>
+        <h3
+          style={{
+            fontSize: '16px',
+            fontWeight: 'bold',
+            color: '#425466',
+            margin: 0,
+            lineHeight: '1.4',
+          }}
+        >
+          {event.title}
+        </h3>
+
+        <p
+          style={{
+            fontSize: '14px',
+            fontWeight: '300',
+            color: '#425466',
+            margin: 0,
+            lineHeight: '1.5',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {event.description}
+        </p>
+
+        <div style={{ fontSize: '14px', fontWeight: '300', color: '#425466' }}>
+          <div>{event.date}</div>
+          {event.time && (
+            <div>{event.time}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,264 @@
+"use client"
+
+import * as React from "react"
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react"
+import { cn } from "@/lib/classnames"
+import { Button } from "@/components/ui/Button"
+import { LeftArrow } from "@/components/icons/LeftArrow"
+import { RightArrow } from "@/components/icons/RightArrow"
+
+type CarouselApi = UseEmblaCarouselType[1]
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
+type CarouselOptions = UseCarouselParameters[0]
+type CarouselPlugin = UseCarouselParameters[1]
+
+type CarouselProps = {
+  opts?: CarouselOptions
+  plugins?: CarouselPlugin
+  orientation?: "horizontal" | "vertical"
+  setApi?: (api: CarouselApi) => void
+}
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
+  api: ReturnType<typeof useEmblaCarousel>[1]
+  scrollPrev: () => void
+  scrollNext: () => void
+  canScrollPrev: boolean
+  canScrollNext: boolean
+} & CarouselProps
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />")
+  }
+
+  return context
+}
+
+const Carousel = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+  (
+    {
+      orientation = "horizontal",
+      opts,
+      setApi,
+      plugins,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [carouselRef, api] = useEmblaCarousel(
+      {
+        ...opts,
+        axis: orientation === "horizontal" ? "x" : "y",
+      },
+      plugins
+    )
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+    const [canScrollNext, setCanScrollNext] = React.useState(false)
+
+    const onSelect = React.useCallback((api: CarouselApi) => {
+      if (!api) {
+        return
+      }
+
+      setCanScrollPrev(api.canScrollPrev())
+      setCanScrollNext(api.canScrollNext())
+    }, [])
+
+    const scrollPrev = React.useCallback(() => {
+      api?.scrollPrev()
+    }, [api])
+
+    const scrollNext = React.useCallback(() => {
+      api?.scrollNext()
+    }, [api])
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault()
+          scrollPrev()
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault()
+          scrollNext()
+        }
+      },
+      [scrollPrev, scrollNext]
+    )
+
+    React.useEffect(() => {
+      if (!api || !setApi) {
+        return
+      }
+
+      setApi(api)
+    }, [api, setApi])
+
+    React.useEffect(() => {
+      if (!api) {
+        return
+      }
+
+      onSelect(api)
+      api.on("reInit", onSelect)
+      api.on("select", onSelect)
+
+      return () => {
+        api?.off("select", onSelect)
+      }
+    }, [api, onSelect])
+
+    return (
+      <CarouselContext.Provider
+        value={{
+          carouselRef,
+          api: api,
+          opts,
+          orientation:
+            orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+          scrollPrev,
+          scrollNext,
+          canScrollPrev,
+          canScrollNext,
+        }}
+      >
+        <div
+          ref={ref}
+          onKeyDownCapture={handleKeyDown}
+          className={cn("relative", className)}
+          role="region"
+          aria-roledescription="carousel"
+          {...props}
+        >
+          {children}
+        </div>
+      </CarouselContext.Provider>
+    )
+  }
+)
+Carousel.displayName = "Carousel"
+
+const CarouselContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    // Allow overflow to be visible so elements like shadows or controls
+    // that extend outside the slide area are not clipped.
+    <div ref={carouselRef} className="overflow-visible">
+      <div
+        ref={ref}
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "" : "flex-col",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+})
+CarouselContent.displayName = "CarouselContent"
+
+const CarouselItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "" : "pt-4",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+CarouselItem.displayName = "CarouselItem"
+
+const CarouselPrevious = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "sm", ...props }, ref) => {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-left-12 top-1/2 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <LeftArrow className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  )
+})
+CarouselPrevious.displayName = "CarouselPrevious"
+
+const CarouselNext = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "sm", ...props }, ref) => {
+  const { orientation, scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-right-12 top-1/2 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <RightArrow className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  )
+})
+CarouselNext.displayName = "CarouselNext"
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+}

--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -1,0 +1,54 @@
+// src/hooks/useEvents.ts
+'use client'
+
+import { useState, useEffect } from 'react'
+import type { Event } from '@/components/EventCard'
+
+interface UseEventsResult {
+  events: Event[]
+  loading: boolean
+  error: string | null
+  refetch: () => void
+}
+
+export function useEvents(): UseEventsResult {
+  const [events, setEvents] = useState<Event[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchEvents = async () => {
+    try {
+      setLoading(true)
+      setError(null)
+
+      const response = await fetch('/api/get-events')
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+
+      const data = await response.json()
+
+      if (data.success) {
+        setEvents(data.events || [])
+      } else {
+        throw new Error(data.error || 'Failed to fetch events')
+      }
+    } catch (err) {
+      console.error('Error fetching events:', err)
+      setError(err instanceof Error ? err.message : 'Failed to fetch events')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const refetch = () => {
+    fetchEvents()
+  }
+
+  useEffect(() => {
+    fetchEvents()
+  }, [])
+
+  return { events, loading, error, refetch }
+}


### PR DESCRIPTION
Introduces an API route to fetch events from a Notion database, a custom React hook for loading events, and a carousel UI for displaying event cards. Integrates embla-carousel-react for carousel functionality and adds EventCard component for event display. Updates events page to use the new hook and carousel, and adds embla-carousel-react to dependencies.