### PR TITLE
Add MembershipSignUp component and integrate in pages

### DIFF
--- a/src/app/(app shell)/schedule/page.client.tsx
+++ b/src/app/(app shell)/schedule/page.client.tsx
@@ -9,6 +9,7 @@ import CalendarWeek from "./CalendarWeek";
 import OutingDrawer from "./OutingDrawer";
 import { getFlagStatus } from "../../../lib/flagStatus";
 import FlagStatusBanner from "../../../components/FlagStatusBanner";
+import MembershipSignUp from "../../../components/MembershipSignUp";
 
 export default function SchedulePageClient() {
        const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
@@ -119,6 +120,13 @@ export default function SchedulePageClient() {
                                                        <p className="text-sm text-muted-foreground">
                                                                Check back later or navigate to a different week.
                                                        </p>
+                                               </div>
+                                       )}
+
+                                       {/* Membership Sign Up - show when there are events */}
+                                       {!loading && stats.hasEvents && (
+                                               <div style={{ width: '100%', paddingTop: '32px' }}>
+                                                       <MembershipSignUp />
                                                </div>
                                        )}
                                </div>

--- a/src/app/coxing/page.client.tsx
+++ b/src/app/coxing/page.client.tsx
@@ -9,6 +9,7 @@ import { useUpdateCoxingAvailability } from '../(app shell)/hooks/useUpdateCoxin
 import { Member } from '@/types/members'
 import { CoxingAvailability } from '@/types/coxing'
 import { getWeekDays } from '@/lib/date'
+import MembershipSignUp from '@/components/MembershipSignUp'
 
 type TimeSlotKey = 'earlyAM' | 'midAM' | 'midPM' | 'latePM'
 
@@ -114,7 +115,7 @@ export default function CoxingPageClient() {
                 <div
                   style={{
                     display: 'grid',
-                    gridTemplateColumns: '160px repeat(7, 110px)',
+                    gridTemplateColumns: 'auto repeat(7, 110px)',
                     gridTemplateRows: '48px repeat(4, 48px)',
                     columnGap: '24px',
                     rowGap: '24px',
@@ -199,6 +200,13 @@ export default function CoxingPageClient() {
         {!selectedMember && (
           <div className="text-center py-6" style={{ width: '100%', marginTop: '32px' }}>
             <p className="text-muted-foreground mb-2">No cox is selected. Select a cox to provide availability.</p>
+          </div>
+        )}
+
+        {/* Membership Sign Up - show when no member is selected */}
+        {!selectedMember && (
+          <div style={{ width: '100%', marginTop: '32px' }}>
+            <MembershipSignUp />
           </div>
         )}
         {updating && (

--- a/src/app/tests/page.client.tsx
+++ b/src/app/tests/page.client.tsx
@@ -9,6 +9,7 @@ import CalendarWeek from "@/app/(app shell)/schedule/CalendarWeek";
 import TestDrawer from "@/app/(app shell)/swim-tests/TestDrawer";
 import { mapTestsToEvents, filterTestEventsByType, filterTestEventsByDateRange, groupTestEventsByDate } from "@/lib/testMappers";
 import { getWeekDays, getDayNameShort, isToday } from "@/lib/date";
+import MembershipSignUp from "@/components/MembershipSignUp";
 
 const testFilterOptions = [
   { value: 'All', label: 'All Tests' },
@@ -241,6 +242,13 @@ export default function TestsPageClient() {
             <p className="text-sm text-muted-foreground">
               Check back later or navigate to a different week.
             </p>
+          </div>
+        )}
+
+        {/* Membership Sign Up - show when there are events */}
+        {!loading && stats.hasEvents && (
+          <div style={{ width: '100%', paddingTop: '32px' }}>
+            <MembershipSignUp />
           </div>
         )}
       </div>

--- a/src/components/MembershipSignUp.tsx
+++ b/src/components/MembershipSignUp.tsx
@@ -36,7 +36,7 @@ export default function MembershipSignUp() {
         gap: '12px'
       }}>
         <p className="text-muted-foreground text-center">
-          Don't see your name in the list of available members?
+          Don&apos;t see your name in the list of available members?
         </p>
         <p className="text-muted-foreground text-center">
           Sign up for SABC membership and your name will appear.

--- a/src/components/MembershipSignUp.tsx
+++ b/src/components/MembershipSignUp.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+
+function ChevronRightIcon({ color = '#4C6FFF' }: { color?: string }) {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M2.90403 1.02903C3.02607 0.90699 3.22393 0.90699 3.34597 1.02903L7.09597 4.77903C7.21801 4.90107 7.21801 5.09893 7.09597 5.22097L3.34597 8.97097C3.22393 9.09301 3.02607 9.09301 2.90403 8.97097C2.78199 8.84893 2.78199 8.65107 2.90403 8.52903L6.43306 5L2.90403 1.47097C2.78199 1.34893 2.78199 1.15107 2.90403 1.02903Z"
+        fill={color}
+      />
+    </svg>
+  );
+}
+
+export default function MembershipSignUp() {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push('/membership');
+  };
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      gap: '32px',
+    }}>
+      <div style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px'
+      }}>
+        <p className="text-muted-foreground text-center">
+          Don't see your name in the list of available members?
+        </p>
+        <p className="text-muted-foreground text-center">
+          Sign up for SABC membership and your name will appear.
+        </p>
+      </div>
+      <button
+        onClick={handleClick}
+        style={{
+          display: 'flex',
+          padding: '12px 20px',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '10px',
+          borderRadius: '6px',
+          background: '#E1E8FF',
+          border: 'none',
+          cursor: 'pointer',
+          transition: 'background-color 0.2s ease',
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.background = '#D1DAFF';
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = '#E1E8FF';
+        }}
+      >
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          alignSelf: 'stretch',
+          gap: '8px'
+        }}>
+          <span style={{
+            color: 'var(--Theme-Primary-Default, #4C6FFF)',
+            fontFamily: 'Gilroy',
+            fontSize: '12px',
+            fontStyle: 'normal',
+            fontWeight: 800,
+            lineHeight: '12px'
+          }}>
+            Membership Sign Up
+          </span>
+          <ChevronRightIcon color="#4C6FFF" />
+        </div>
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Introduces a new MembershipSignUp component for prompting users to sign up for SABC membership. Integrates this component into the schedule, coxing, and tests pages, displaying it contextually when relevant (e.g., when no member is selected or when events are present).