### PR TITLE
Add FAQs page and navigation link

### DIFF
--- a/src/app/(app shell)/sidebar/ChatIcon.tsx
+++ b/src/app/(app shell)/sidebar/ChatIcon.tsx
@@ -1,0 +1,15 @@
+export function ChatIcon(props: React.SVGProps<SVGSVGElement> & { stroke?: string }) {
+  const strokeColor = props.stroke || "#425466";
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <g id="Iconly/Regular/Light/Chat">
+        <g id="Chat">
+          <path id="Stroke 4" fillRule="evenodd" clipRule="evenodd" d="M19.0714 19.07C16.0152 22.1265 11.4898 22.7868 7.78642 21.0741C7.23971 20.854 6.79148 20.6761 6.36537 20.6761C5.17849 20.6832 3.70117 21.834 2.93336 21.0671C2.16555 20.2992 3.31726 18.8207 3.31726 17.6267C3.31726 17.2005 3.14642 16.7603 2.92632 16.2125C1.21283 12.5097 1.87411 7.98281 4.93026 4.92733C8.8316 1.02455 15.17 1.02455 19.0714 4.92632C22.9797 8.83513 22.9727 15.1682 19.0714 19.07Z" stroke={strokeColor} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+          <path id="Stroke 11" d="M15.9393 12.4131H15.9483" stroke={strokeColor} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+          <path id="Stroke 13" d="M11.9303 12.4131H11.9393" stroke={strokeColor} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+          <path id="Stroke 15" d="M7.92128 12.4131H7.93028" stroke={strokeColor} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/src/app/(app shell)/sidebar/Sidebar.tsx
+++ b/src/app/(app shell)/sidebar/Sidebar.tsx
@@ -6,6 +6,7 @@ import SwimIcon from "./SwimIcon";
 import PersonIcon from "./PersonIcon";
 import { MoreSquareIcon } from "./MoreSquareIcon";
 import { SendIcon } from "./SendIcon";
+import { ChatIcon } from "./ChatIcon";
 import { HomeIcon } from "./HomeIcon";
 import { CoxingIcon } from "./CoxingIcon";
 import { EventsIcon } from "./EventsIcon";
@@ -157,6 +158,12 @@ export default function Sidebar() {
             label="Feedback"
             icon={<SendIcon width={20} height={20} stroke={pathname?.startsWith("/feedback") ? "#fff" : "#425466"} />}
             active={pathname?.startsWith("/feedback")}
+          />
+          <NavItem
+            href="/faqs"
+            label="FAQs"
+            icon={<ChatIcon stroke={pathname?.startsWith("/faqs") ? "#fff" : "#425466"} />}
+            active={pathname?.startsWith("/faqs")}
           />
         </div>
       </Box>

--- a/src/app/faqs/page.client.tsx
+++ b/src/app/faqs/page.client.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+export default function FAQsPageClient() {
+  return (
+    <div className="container mx-auto p-2 mobile-faqs-page">
+      <h1 className="font-bold mobile-hide-header" style={{ fontSize: '32px' }}>FAQs</h1>
+      <div className="w-full">
+        <iframe
+          src="https://stantonysboatclub.notion.site/ebd/28080040a8fa80d5a2e4fee3d8cb2ef6"
+          width="100%"
+          height="800px"
+          style={{ border: 0 }}
+          allow="fullscreen"
+          title="SABC FAQs"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/faqs/page.tsx
+++ b/src/app/faqs/page.tsx
@@ -1,0 +1,7 @@
+import FAQsPageClient from './page.client';
+
+export const metadata = { title: 'FAQs' };
+
+export default function FAQsPage() {
+  return <FAQsPageClient />;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -231,6 +231,12 @@ select:focus-visible {
     margin-top: 20px !important;
   }
 
+  /* Mobile FAQs page */
+  .mobile-faqs-page {
+    padding-top: 60px !important;
+    margin-top: 20px !important;
+  }
+
   /* Mobile coxing page */
   .mobile-coxing-page {
     padding-top: 60px !important;

--- a/src/components/ResponsiveLayout.tsx
+++ b/src/components/ResponsiveLayout.tsx
@@ -26,6 +26,7 @@ export default function ResponsiveLayout({ children }: ResponsiveLayoutProps) {
     if (pathname?.startsWith('/events')) return 'Events';
     if (pathname?.startsWith('/membership')) return 'Membership';
     if (pathname?.startsWith('/feedback')) return 'Feedback';
+    if (pathname?.startsWith('/faqs')) return 'FAQs';
     if (pathname?.startsWith('/coxing')) return 'Coxing';
     return 'SABC';
   };

--- a/src/components/mobile/MobileDrawer.tsx
+++ b/src/components/mobile/MobileDrawer.tsx
@@ -105,6 +105,17 @@ function SendIcon({ stroke = "#425466" }: { stroke?: string }) {
   );
 }
 
+function ChatIcon({ stroke = "#425466" }: { stroke?: string }) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path fillRule="evenodd" clipRule="evenodd" d="M19.0714 19.07C16.0152 22.1265 11.4898 22.7868 7.78642 21.0741C7.23971 20.854 6.79148 20.6761 6.36537 20.6761C5.17849 20.6832 3.70117 21.834 2.93336 21.0671C2.16555 20.2992 3.31726 18.8207 3.31726 17.6267C3.31726 17.2005 3.14642 16.7603 2.92632 16.2125C1.21283 12.5097 1.87411 7.98281 4.93026 4.92733C8.8316 1.02455 15.17 1.02455 19.0714 4.92632C22.9797 8.83513 22.9727 15.1682 19.0714 19.07Z" stroke={stroke} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M15.9393 12.4131H15.9483" stroke={stroke} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M11.9303 12.4131H11.9393" stroke={stroke} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M7.92128 12.4131H7.93028" stroke={stroke} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  );
+}
+
 export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
   // Close drawer on escape key
   useEffect(() => {
@@ -204,6 +215,12 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
             href="/feedback"
             icon={<SendIcon />}
             label="Feedback"
+            onClick={onClose}
+          />
+          <MobileNavItem
+            href="/faqs"
+            icon={<ChatIcon />}
+            label="FAQs"
             onClick={onClose}
           />
         </nav>


### PR DESCRIPTION
Introduces a new FAQs page with an embedded Notion iframe, adds a ChatIcon component, and updates both sidebar and mobile navigation to include a link to the FAQs. Also updates global styles for mobile FAQs page and ensures the page title is set appropriately.