### PR TITLE
Add iCalendar file download for mobile calendar integration

### DIFF
--- a/src/utils/calendarLinks.ts
+++ b/src/utils/calendarLinks.ts
@@ -63,3 +63,86 @@ export function extractPlainTextFromRichText(richText: unknown): string | undefi
   return text.length > 0 ? text : undefined;
 }
 
+interface ICalendarOptions {
+  title: string;
+  description?: string;
+  start: Date;
+  end: Date;
+  location?: string;
+}
+
+/**
+ * Formats a Date into the YYYYMMDDTHHmmssZ format required by iCalendar files.
+ */
+function formatDateForICalendar(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+}
+
+/**
+ * Escapes special characters in iCalendar text fields.
+ */
+function escapeICalendarText(text: string): string {
+  return text
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\n/g, '\\n');
+}
+
+/**
+ * Builds an iCalendar (.ics) file content that can be downloaded and opened in calendar apps.
+ * This is especially useful for mobile devices where it will prompt to open in the native calendar app.
+ */
+export function buildICalendarFile({
+  title,
+  description,
+  start,
+  end,
+  location,
+}: ICalendarOptions): string {
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//SABC//Rowing Schedule//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:REQUEST',
+    'BEGIN:VEVENT',
+    `DTSTART:${formatDateForICalendar(start)}`,
+    `DTEND:${formatDateForICalendar(end)}`,
+    `DTSTAMP:${formatDateForICalendar(new Date())}`,
+    `UID:${start.getTime()}-${Math.random().toString(36).substring(7)}@sabc.app`,
+    `SUMMARY:${escapeICalendarText(title)}`,
+  ];
+
+  if (description) {
+    lines.push(`DESCRIPTION:${escapeICalendarText(description)}`);
+  }
+
+  if (location) {
+    lines.push(`LOCATION:${escapeICalendarText(location)}`);
+  }
+
+  lines.push(
+    'STATUS:CONFIRMED',
+    'SEQUENCE:0',
+    'END:VEVENT',
+    'END:VCALENDAR'
+  );
+
+  return lines.join('\r\n');
+}
+
+/**
+ * Downloads an iCalendar file to the user's device.
+ * On mobile, this will typically prompt to open in the default calendar app.
+ */
+export function downloadICalendarFile(icsContent: string, filename: string = 'event.ics'): void {
+  const blob = new Blob([icsContent], { type: 'text/calendar;charset=utf-8' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
+}


### PR DESCRIPTION
Introduces functions to build and download iCalendar (.ics) files for outing events, enabling mobile users to add events to their calendar apps. The OutingDrawer now detects mobile devices and downloads an .ics file instead of opening a Google Calendar link, improving cross-platform calendar integration.