### PR TITLE
feat: filter Events page to hide past events

### DIFF
--- a/src/app/api/get-events/route.ts
+++ b/src/app/api/get-events/route.ts
@@ -10,9 +10,17 @@ export async function GET() {
   try {
     const databaseId = resolveEventsDatabaseId()
 
+    const today = new Date().toLocaleDateString('en-CA', { timeZone: 'Europe/London' })
+
     const pages = await queryDataSource<any>(
       databaseId,
       {
+        filter: {
+          property: 'Date',
+          date: {
+            on_or_after: today,
+          },
+        },
         sorts: [
           {
             property: 'Date',


### PR DESCRIPTION
## Summary

Filters the Events page (`/events`) so only events with a date on or after today are shown. Closes [PER-165](https://linear.app/eawanders/issue/PER-165/filter-events-page-to-hide-past-events).

**Approach:** server-side Notion `filter` on the `Date` property with `on_or_after: today` in `src/app/api/get-events/route.ts`. `today` is computed inside the GET handler (UK time, `Europe/London`) so it's recomputed on each request and stays correct across the `revalidate = 120` cache window. Past events are never sent to the client.

## Test Coverage

The repo has no test framework configured, so no tests were added. The change is a single Notion query parameter on one API route. Manual verification:

- [x] `tsc --noEmit` passes.
- [x] Local dev server starts cleanly on `http://localhost:3000`.
- [ ] Manual check on the Vercel preview that past events disappear and an event dated today still shows.

## Pre-Landing Review

No issues found. No SQL, no LLM trust boundary, no auth surface changes. Notion filter syntax is valid. Events with no Date property are excluded automatically. Around midnight the 2-minute cache window may briefly serve a stale "today" — acceptable trade-off.

## Plan Completion

- [x] Filter `/events` so only events with `dateTime >= today (00:00 local)` render.
- [x] Preserve ascending sort by date.
- [x] Empty-state ("No upcoming events") still works when filtered list is empty.
- [x] Implemented at the API layer (preferred approach in the ticket).
- [x] `revalidate = 120` cache window: today recomputed per request, not at module load.

## Test plan

- [ ] On the Vercel preview, open `/events` — confirm no past events appear.
- [ ] Confirm an event dated today (any time) still shows.
- [ ] Confirm sort order remains ascending by date.
- [ ] Confirm empty state renders if Notion has no upcoming events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)