### PR TITLE
Add /marshalling page + Notion-backed signup DB for Eights 2026

### DIFF
--- a/src/app/(app shell)/marshalling/MarshalDrawer.tsx
+++ b/src/app/(app shell)/marshalling/MarshalDrawer.tsx
@@ -1,0 +1,349 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import Sheet from '@/components/ui/Sheet';
+import type {
+  ClashCrew,
+  MarshalPersonStatus,
+  MarshalSlot,
+} from '@/types/marshal';
+import type { Member } from '@/types/members';
+
+const STATUS_OPTIONS: MarshalPersonStatus[] = [
+  'Open',
+  'Reserved',
+  'Maybe Available',
+  'Awaiting Approval',
+  'Confirmed',
+  'Not Available',
+];
+
+interface MarshalDrawerProps {
+  slot: MarshalSlot;
+  members: Member[];
+  isOpen: boolean;
+  onClose: () => void;
+  onChange: () => void;
+}
+
+function formatTimeRange(start: string, end?: string) {
+  const fmt = (d: Date) =>
+    d.toLocaleTimeString('en-GB', {
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZone: 'Europe/London',
+    });
+  if (!end) return fmt(new Date(start));
+  return `${fmt(new Date(start))}–${fmt(new Date(end))}`;
+}
+
+function formatDate(start: string) {
+  return new Date(start).toLocaleDateString('en-GB', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    timeZone: 'Europe/London',
+  });
+}
+
+export default function MarshalDrawer({
+  slot,
+  members,
+  isOpen,
+  onClose,
+  onChange,
+}: MarshalDrawerProps) {
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(slot.person?.id ?? null);
+  const [status, setStatus] = useState<MarshalPersonStatus>(slot.personStatus);
+  const [query, setQuery] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelectedMemberId(slot.person?.id ?? null);
+    setStatus(slot.personStatus);
+    setQuery('');
+    setError(null);
+  }, [slot.id, slot.person?.id, slot.personStatus]);
+
+  const filteredMembers = useMemo(() => {
+    if (!query.trim()) return members;
+    const q = query.toLowerCase();
+    return members.filter(
+      (m) => m.name.toLowerCase().includes(q) || (m.email || '').toLowerCase().includes(q)
+    );
+  }, [members, query]);
+
+  async function saveAssignment(newMemberId: string | null) {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/assign-marshal', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slotId: slot.id, memberId: newMemberId }),
+      });
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error || 'Failed to assign');
+      onChange();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function saveStatus(newStatus: MarshalPersonStatus) {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/update-marshal-status', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slotId: slot.id, status: newStatus }),
+      });
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error || 'Failed to update');
+      onChange();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handlePick(memberId: string | null) {
+    setSelectedMemberId(memberId);
+    await saveAssignment(memberId);
+  }
+
+  async function handleStatusChange(next: MarshalPersonStatus) {
+    setStatus(next);
+    await saveStatus(next);
+  }
+
+  return (
+    <Sheet isOpen={isOpen} onClose={onClose} title={slot.name}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+        <section style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px' }}>
+          <Detail label="Date" value={formatDate(slot.startTime)} />
+          <Detail label="Time" value={formatTimeRange(slot.startTime, slot.endTime)} />
+          <Detail label="Role" value={`${slot.role ?? '—'} · ${slot.shift ?? ''}`} />
+          <Detail label="Location" value={slot.location ?? '—'} />
+        </section>
+
+        {slot.clashCrews.length > 0 && <ClashWarning crews={slot.clashCrews} />}
+
+        {slot.notes && (
+          <div
+            style={{
+              padding: '12px 14px',
+              background: '#F8FAFC',
+              borderRadius: '8px',
+              fontSize: '13px',
+              color: '#475569',
+              lineHeight: 1.5,
+            }}
+          >
+            {slot.notes}
+          </div>
+        )}
+
+        <section style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          <label style={labelStyle}>Signed up</label>
+          {selectedMemberId ? (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '10px 14px',
+                background: '#EEF6FF',
+                border: '1px solid #BFDBFE',
+                borderRadius: '8px',
+              }}
+            >
+              <span style={{ color: '#161736', fontWeight: 600 }}>
+                {members.find((m) => m.id === selectedMemberId)?.name ?? 'Selected'}
+              </span>
+              <button
+                type="button"
+                disabled={saving}
+                onClick={() => handlePick(null)}
+                style={clearBtnStyle}
+              >
+                Clear
+              </button>
+            </div>
+          ) : (
+            <>
+              <input
+                type="search"
+                placeholder="Search members…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                style={inputStyle}
+              />
+              <div
+                style={{
+                  maxHeight: '240px',
+                  overflowY: 'auto',
+                  border: '1px solid #DFE5F1',
+                  borderRadius: '8px',
+                }}
+              >
+                {filteredMembers.length === 0 ? (
+                  <div style={{ padding: '12px', color: '#94A3B8', fontSize: '13px' }}>
+                    No matching members.
+                  </div>
+                ) : (
+                  filteredMembers.map((m) => (
+                    <button
+                      key={m.id}
+                      type="button"
+                      onClick={() => handlePick(m.id)}
+                      disabled={saving}
+                      style={memberRowStyle}
+                    >
+                      <span style={{ fontWeight: 600 }}>{m.name}</span>
+                      <span style={{ color: '#94A3B8', fontSize: '12px' }}>{m.memberType}</span>
+                    </button>
+                  ))
+                )}
+              </div>
+            </>
+          )}
+        </section>
+
+        <section style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          <label style={labelStyle}>Status</label>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+            {STATUS_OPTIONS.map((opt) => (
+              <button
+                key={opt}
+                type="button"
+                disabled={saving}
+                onClick={() => handleStatusChange(opt)}
+                style={{
+                  ...chipBtnStyle,
+                  background: status === opt ? '#0177FB' : '#F1F5F9',
+                  color: status === opt ? '#FFF' : '#475569',
+                }}
+              >
+                {opt}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        {error && (
+          <div
+            style={{
+              padding: '12px',
+              borderRadius: '8px',
+              background: '#FEE2E2',
+              color: '#B91C1C',
+              fontSize: '13px',
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {saving && (
+          <p style={{ color: '#64748B', fontSize: '13px', margin: 0 }}>Saving…</p>
+        )}
+      </div>
+    </Sheet>
+  );
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+      <span style={labelStyle}>{label}</span>
+      <span style={{ color: '#161736', fontSize: '14px', fontWeight: 600 }}>{value}</span>
+    </div>
+  );
+}
+
+function ClashWarning({ crews }: { crews: ClashCrew[] }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: '10px',
+        alignItems: 'flex-start',
+        padding: '12px 14px',
+        background: '#FEF3C7',
+        border: '1px solid #FCD34D',
+        borderRadius: '8px',
+      }}
+    >
+      <span aria-hidden style={{ fontSize: '18px' }}>⚠️</span>
+      <div style={{ fontSize: '13px', color: '#92400E', lineHeight: 1.5 }}>
+        <strong>Crew clash:</strong> Rowers in{' '}
+        {crews.map((c, i) => (
+          <span key={c} style={{ fontWeight: 700 }}>
+            {c}
+            {i < crews.length - 1 ? ', ' : ''}
+          </span>
+        ))}{' '}
+        cannot take this slot (race time ± 1 hr falls within the shift).
+      </div>
+    </div>
+  );
+}
+
+const labelStyle: React.CSSProperties = {
+  color: '#94A3B8',
+  fontSize: '11px',
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: 0.5,
+};
+
+const inputStyle: React.CSSProperties = {
+  padding: '10px 12px',
+  border: '1px solid #DFE5F1',
+  borderRadius: '8px',
+  fontSize: '14px',
+  fontFamily: 'Gilroy',
+};
+
+const memberRowStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  width: '100%',
+  padding: '10px 14px',
+  background: '#FFF',
+  border: 'none',
+  borderBottom: '1px solid #F1F5F9',
+  textAlign: 'left',
+  cursor: 'pointer',
+  fontFamily: 'Gilroy',
+  fontSize: '14px',
+  color: '#161736',
+};
+
+const clearBtnStyle: React.CSSProperties = {
+  padding: '4px 10px',
+  borderRadius: '6px',
+  background: '#FFF',
+  border: '1px solid #BFDBFE',
+  color: '#1D4ED8',
+  fontSize: '12px',
+  fontWeight: 600,
+  cursor: 'pointer',
+};
+
+const chipBtnStyle: React.CSSProperties = {
+  padding: '6px 12px',
+  borderRadius: '999px',
+  border: 'none',
+  fontSize: '13px',
+  fontWeight: 600,
+  cursor: 'pointer',
+  fontFamily: 'Gilroy',
+};

--- a/src/app/(app shell)/marshalling/MarshallingPageClient.tsx
+++ b/src/app/(app shell)/marshalling/MarshallingPageClient.tsx
@@ -1,0 +1,290 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type {
+  MarshalDay,
+  MarshalPersonStatus,
+  MarshalSlot,
+} from '@/types/marshal';
+import type { Member } from '@/types/members';
+import MarshalDrawer from './MarshalDrawer';
+
+const DAY_ORDER: MarshalDay[] = ['Wed', 'Thu', 'Fri', 'Sat'];
+
+const DAY_FULL: Record<MarshalDay, string> = {
+  Wed: 'Wednesday 27 May',
+  Thu: 'Thursday 28 May',
+  Fri: 'Friday 29 May',
+  Sat: 'Saturday 30 May',
+};
+
+const ROLE_COLORS: Record<string, string> = {
+  Marshal: '#0177FB',
+  Umpire: '#F97316',
+  'Static Umpire': '#A855F7',
+};
+
+const STATUS_COLORS: Record<MarshalPersonStatus, { bg: string; fg: string }> = {
+  Open: { bg: '#F1F5F9', fg: '#64748B' },
+  Reserved: { bg: '#E2E8F0', fg: '#475569' },
+  'Maybe Available': { bg: '#DBEAFE', fg: '#1D4ED8' },
+  'Awaiting Approval': { bg: '#FEF3C7', fg: '#B45309' },
+  Confirmed: { bg: '#DCFCE7', fg: '#15803D' },
+  'Not Available': { bg: '#FEE2E2', fg: '#B91C1C' },
+};
+
+function formatTimeRange(start: string, end?: string) {
+  const fmt = (d: Date) =>
+    d.toLocaleTimeString('en-GB', {
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZone: 'Europe/London',
+    });
+  if (!end) return fmt(new Date(start));
+  return `${fmt(new Date(start))}–${fmt(new Date(end))}`;
+}
+
+export default function MarshallingPageClient() {
+  const [slots, setSlots] = useState<MarshalSlot[]>([]);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const loadSlots = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/get-marshals', { cache: 'no-store' });
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error || 'Failed to load');
+      setSlots(data.slots ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const loadMembers = useCallback(async () => {
+    try {
+      const res = await fetch('/api/get-members', { cache: 'no-store' });
+      const data = await res.json();
+      if (data.success) setMembers(data.members ?? []);
+    } catch (e) {
+      console.error('Failed to load members', e);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadSlots();
+    loadMembers();
+  }, [loadSlots, loadMembers]);
+
+  const slotsByDay = useMemo(() => {
+    const map: Record<MarshalDay, MarshalSlot[]> = { Wed: [], Thu: [], Fri: [], Sat: [] };
+    for (const s of slots) {
+      if (s.day && map[s.day]) map[s.day].push(s);
+    }
+    for (const day of DAY_ORDER) {
+      map[day].sort(
+        (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+      );
+    }
+    return map;
+  }, [slots]);
+
+  const selectedSlot = useMemo(
+    () => slots.find((s) => s.id === selectedId) ?? null,
+    [slots, selectedId]
+  );
+
+  const counts = useMemo(() => {
+    const total = slots.length;
+    const filled = slots.filter((s) => s.person && s.personStatus !== 'Open').length;
+    const confirmed = slots.filter((s) => s.personStatus === 'Confirmed').length;
+    return { total, filled, confirmed };
+  }, [slots]);
+
+  return (
+    <main
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '32px',
+        padding: '32px',
+        boxSizing: 'border-box',
+        width: '100%',
+      }}
+    >
+      <header style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        <h1
+          style={{
+            color: '#161736',
+            fontFamily: 'Gilroy',
+            fontSize: '32px',
+            fontWeight: 800,
+            margin: 0,
+          }}
+        >
+          Marshalling & Umpires
+        </h1>
+        <p style={{ color: '#425466', fontFamily: 'Gilroy', fontSize: '16px', margin: 0 }}>
+          St Antony&apos;s commitments for Summer Eights 2026 (27–30 May). Click a slot to sign up.
+          Slots tagged with a crew warning cannot be taken by rowers in that crew (race time ± 1 hr
+          falls within the shift).
+        </p>
+        <p
+          style={{
+            color: '#64748B',
+            fontFamily: 'Gilroy',
+            fontSize: '13px',
+            margin: '4px 0 0 0',
+          }}
+        >
+          {loading
+            ? 'Loading…'
+            : `${counts.filled} / ${counts.total} filled · ${counts.confirmed} confirmed`}
+        </p>
+      </header>
+
+      {error && (
+        <div
+          style={{
+            padding: '16px',
+            borderRadius: '8px',
+            background: '#FEE2E2',
+            color: '#B91C1C',
+          }}
+        >
+          Failed to load: {error}
+        </div>
+      )}
+
+      {DAY_ORDER.map((day) => {
+        const daySlots = slotsByDay[day];
+        if (!daySlots.length) return null;
+        return (
+          <section key={day} style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+            <h2
+              style={{
+                color: '#161736',
+                fontFamily: 'Gilroy',
+                fontSize: '20px',
+                fontWeight: 700,
+                margin: 0,
+                paddingBottom: '4px',
+                borderBottom: '1px solid #DFE5F1',
+              }}
+            >
+              {DAY_FULL[day]}
+            </h2>
+            <div style={{ display: 'grid', gap: '8px' }}>
+              {daySlots.map((slot) => (
+                <SlotRow
+                  key={slot.id}
+                  slot={slot}
+                  onClick={() => setSelectedId(slot.id)}
+                />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+
+      {selectedSlot && (
+        <MarshalDrawer
+          slot={selectedSlot}
+          members={members}
+          isOpen={!!selectedSlot}
+          onClose={() => setSelectedId(null)}
+          onChange={() => loadSlots()}
+        />
+      )}
+    </main>
+  );
+}
+
+function SlotRow({ slot, onClick }: { slot: MarshalSlot; onClick: () => void }) {
+  const statusColors = STATUS_COLORS[slot.personStatus] ?? STATUS_COLORS.Open;
+  const roleColor = slot.role ? ROLE_COLORS[slot.role] : '#0177FB';
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '140px 170px minmax(180px, 1fr) minmax(160px, 1fr) 160px minmax(160px, 1fr)',
+        gap: '12px',
+        alignItems: 'center',
+        background: '#FFF',
+        border: '1px solid #DFE5F1',
+        borderRadius: '12px',
+        padding: '14px 16px',
+        textAlign: 'left',
+        cursor: 'pointer',
+        boxShadow: '0 1px 2px rgba(0,0,0,0.02)',
+        fontFamily: 'Gilroy',
+        color: '#161736',
+        fontSize: '14px',
+      }}
+    >
+      <span style={{ fontWeight: 600 }}>{formatTimeRange(slot.startTime, slot.endTime)}</span>
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '6px',
+          padding: '4px 10px',
+          borderRadius: '999px',
+          background: `${roleColor}15`,
+          color: roleColor,
+          fontWeight: 600,
+          fontSize: '12px',
+          width: 'fit-content',
+        }}
+      >
+        {slot.role ?? '—'} · {slot.shift ?? ''}
+      </span>
+      <span style={{ color: '#425466', fontSize: '13px' }}>{slot.location ?? '—'}</span>
+      <span style={{ color: '#161736' }}>
+        {slot.person ? slot.person.name : <em style={{ color: '#94A3B8' }}>Unfilled</em>}
+      </span>
+      <span
+        style={{
+          display: 'inline-flex',
+          padding: '4px 10px',
+          borderRadius: '999px',
+          background: statusColors.bg,
+          color: statusColors.fg,
+          fontSize: '12px',
+          fontWeight: 600,
+          width: 'fit-content',
+        }}
+      >
+        {slot.personStatus}
+      </span>
+      <span style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', alignItems: 'center' }}>
+        {slot.clashCrews.length > 0 ? (
+          slot.clashCrews.map((c) => (
+            <span
+              key={c}
+              title="Rowers in this crew cannot take this slot"
+              style={{
+                padding: '2px 8px',
+                borderRadius: '999px',
+                background: '#FEE2E2',
+                color: '#B91C1C',
+                fontSize: '11px',
+                fontWeight: 700,
+              }}
+            >
+              ⚠ {c}
+            </span>
+          ))
+        ) : (
+          <span style={{ color: '#94A3B8', fontSize: '12px' }}>No clashes</span>
+        )}
+      </span>
+    </button>
+  );
+}

--- a/src/app/(app shell)/marshalling/page.tsx
+++ b/src/app/(app shell)/marshalling/page.tsx
@@ -1,0 +1,10 @@
+// src/app/(app shell)/marshalling/page.tsx
+
+import MarshallingPageClient from './MarshallingPageClient';
+
+export const metadata = { title: 'Marshalling & Umpires' };
+export const dynamic = 'force-dynamic';
+
+export default function MarshallingPage() {
+  return <MarshallingPageClient />;
+}

--- a/src/app/(app shell)/sidebar/MarshalIcon.tsx
+++ b/src/app/(app shell)/sidebar/MarshalIcon.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+export default function MarshalIcon(
+  props: React.SVGProps<SVGSVGElement> & { stroke?: string }
+) {
+  const strokeColor = props.stroke || "#425466";
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M9 11V4a1 1 0 0 1 1.5-.866l9 5.25a1 1 0 0 1 0 1.732l-9 5.25A1 1 0 0 1 9 14.598V13H6a3 3 0 1 1 0-6h3z"
+        stroke={strokeColor}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M5 19c2 1 4 1 6 0"
+        stroke={strokeColor}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/src/app/(app shell)/sidebar/Sidebar.tsx
+++ b/src/app/(app shell)/sidebar/Sidebar.tsx
@@ -12,6 +12,7 @@ import { CoxingIcon } from "./CoxingIcon";
 import { RowerIcon } from "./RowerIcon";
 import { CalendarIcon } from "./CalendarIcon";
 import { EventsIcon } from "./EventsIcon";
+import MarshalIcon from "./MarshalIcon";
 import { usePathname, useRouter } from "next/navigation";
 import Box from "@/components/ui/Box";
 import ActionButton from "@/components/ui/ActionButton";
@@ -141,6 +142,12 @@ export default function Sidebar() {
             label="OURC Tests"
             icon={<SwimIcon stroke="#425466" />}
             active={pathname?.startsWith("/tests")}
+          />
+          <NavItem
+            href="/marshalling"
+            label="Marshalling"
+            icon={<MarshalIcon stroke={pathname?.startsWith("/marshalling") ? "#fff" : "#425466"} />}
+            active={pathname?.startsWith("/marshalling")}
           />
           <NavItem
             href="/events"

--- a/src/app/api/assign-marshal/route.ts
+++ b/src/app/api/assign-marshal/route.ts
@@ -1,0 +1,60 @@
+// src/app/api/assign-marshal/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { Client } from '@notionhq/client';
+
+const notion = new Client({
+  auth: process.env.NOTION_TOKEN,
+  notionVersion: '2025-09-03',
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const { slotId, memberId } = await request.json();
+
+    if (!slotId) {
+      return NextResponse.json(
+        { error: 'Missing required field: slotId', success: false },
+        { status: 400 }
+      );
+    }
+
+    const properties: Record<string, unknown> = {};
+
+    if (memberId) {
+      properties['Person'] = { relation: [{ id: memberId }] };
+
+      const slotPage = await notion.pages.retrieve({ page_id: slotId });
+      const current =
+        (slotPage as { properties?: Record<string, { select?: { name?: string } }> })
+          .properties?.['Person Status']?.select?.name;
+      const skipSet = current && ['Confirmed', 'Reserved', 'Not Available'].includes(current);
+      if (!skipSet) {
+        properties['Person Status'] = { select: { name: 'Awaiting Approval' } };
+      }
+    } else {
+      properties['Person'] = { relation: [] };
+      properties['Person Status'] = { select: { name: 'Open' } };
+    }
+
+    await notion.pages.update({
+      page_id: slotId,
+      properties: properties as any,
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: memberId ? 'Member assigned to marshal slot' : 'Marshal slot cleared',
+      slotId,
+      memberId,
+    });
+  } catch (error) {
+    console.error('❌ Error assigning marshal slot:', error);
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : 'Unknown error occurred',
+        success: false,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/get-marshals/route.ts
+++ b/src/app/api/get-marshals/route.ts
@@ -1,0 +1,32 @@
+// src/app/api/get-marshals/route.ts
+import { NextResponse } from 'next/server';
+import { getMarshals } from '@/server/notion/marshals';
+import { startTiming, createServerTiming } from '@/server/timing';
+
+export const revalidate = 30;
+
+export async function GET() {
+  const start = startTiming();
+  try {
+    const slots = await getMarshals();
+    const published = slots.filter((s) => s.publish);
+    const response = NextResponse.json({
+      slots: published,
+      success: true,
+      count: published.length,
+    });
+    response.headers.set('Server-Timing', createServerTiming(start));
+    return response;
+  } catch (error) {
+    console.error('❌ Error in get-marshals API:', error);
+    const response = NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : 'Unknown error occurred',
+        success: false,
+      },
+      { status: 500 }
+    );
+    response.headers.set('Server-Timing', createServerTiming(start));
+    return response;
+  }
+}

--- a/src/app/api/update-marshal-status/route.ts
+++ b/src/app/api/update-marshal-status/route.ts
@@ -1,0 +1,64 @@
+// src/app/api/update-marshal-status/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+import { Client } from '@notionhq/client';
+import type { MarshalPersonStatus } from '@/types/marshal';
+
+const notion = new Client({
+  auth: process.env.NOTION_TOKEN,
+  notionVersion: '2025-09-03',
+});
+
+const VALID_STATUSES: MarshalPersonStatus[] = [
+  'Open',
+  'Reserved',
+  'Maybe Available',
+  'Awaiting Approval',
+  'Confirmed',
+  'Not Available',
+];
+
+export async function POST(request: NextRequest) {
+  try {
+    const { slotId, status } = await request.json();
+
+    if (!slotId || !status) {
+      return NextResponse.json(
+        { error: 'Missing required fields: slotId, status', success: false },
+        { status: 400 }
+      );
+    }
+
+    if (!VALID_STATUSES.includes(status as MarshalPersonStatus)) {
+      return NextResponse.json(
+        {
+          error: `Invalid status. Must be one of: ${VALID_STATUSES.join(', ')}`,
+          success: false,
+        },
+        { status: 400 }
+      );
+    }
+
+    await notion.pages.update({
+      page_id: slotId,
+      properties: {
+        'Person Status': { select: { name: status } },
+      } as any,
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: `Marshal slot status updated to ${status}`,
+      slotId,
+      status,
+    });
+  } catch (error) {
+    console.error('❌ Error updating marshal status:', error);
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : 'Unknown error occurred',
+        success: false,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/server/notion/marshals.ts
+++ b/src/server/notion/marshals.ts
@@ -1,0 +1,107 @@
+// src/server/notion/marshals.ts
+
+import { cache } from 'react';
+import type { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+import type {
+  ClashCrew,
+  MarshalDay,
+  MarshalEvent,
+  MarshalLocation,
+  MarshalPersonStatus,
+  MarshalRole,
+  MarshalShift,
+  MarshalSlot,
+} from '@/types/marshal';
+import type { Member } from '@/types/members';
+import { queryDataSource } from './query';
+import { getMembers } from './members';
+
+const DEFAULT_MARSHALS_DB_ID = 'a7d958881fd84cbe92c80f3d659391fd';
+
+function resolveMarshalsDatabaseId() {
+  const explicit = process.env.NOTION_MARSHALS_DB_ID;
+  if (explicit && explicit.trim().length > 0) return explicit.trim();
+  return DEFAULT_MARSHALS_DB_ID;
+}
+
+async function fetchMarshalsInternal(): Promise<MarshalSlot[]> {
+  const databaseId = resolveMarshalsDatabaseId();
+  const pages = await queryDataSource<PageObjectResponse>(
+    databaseId,
+    {
+      sorts: [{ property: 'Slot Time', direction: 'ascending' }],
+    },
+    'marshals.query'
+  );
+  const members = await getMembers();
+  const memberMap = new Map(members.map((m) => [m.id, m] as const));
+  return pages
+    .map((page) => mapMarshal(page, memberMap))
+    .filter((s): s is MarshalSlot => Boolean(s));
+}
+
+export const getMarshals = cache(fetchMarshalsInternal);
+
+function mapMarshal(
+  page: PageObjectResponse,
+  memberMap: Map<string, Member>
+): MarshalSlot | null {
+  const props = page.properties as Record<string, any>;
+  const name = extractPlainText(props['Name']);
+  const date = props['Slot Time']?.date;
+  if (!name || !date?.start) return null;
+
+  const persons = mapRelationMembers(props['Person'], memberMap);
+
+  return {
+    id: page.id,
+    url: page.url,
+    name,
+    slotId: props['Slot ID']?.unique_id?.number ?? undefined,
+    event: props['Event']?.select?.name as MarshalEvent | undefined,
+    day: props['Day']?.select?.name as MarshalDay | undefined,
+    role: props['Role']?.select?.name as MarshalRole | undefined,
+    shift: props['Shift']?.select?.name as MarshalShift | undefined,
+    location: props['Location']?.select?.name as MarshalLocation | undefined,
+    startTime: date.start,
+    endTime: date.end || undefined,
+    isDatetime: date.start.includes('T'),
+    person: persons[0],
+    personStatus:
+      (props['Person Status']?.select?.name as MarshalPersonStatus | undefined) ?? 'Open',
+    clashCrews: ((props['Clash Crews']?.multi_select ?? []) as { name: string }[])
+      .map((s) => s.name as ClashCrew)
+      .filter(Boolean),
+    notes: extractPlainText(props['Notes']),
+    publish: Boolean(props['Publish']?.checkbox),
+  };
+}
+
+function mapRelationMembers(property: any, memberMap: Map<string, Member>): Member[] {
+  if (!property?.relation) return [];
+  return property.relation
+    .map(({ id }: { id: string }) => memberMap.get(id))
+    .filter((m: Member | undefined): m is Member => Boolean(m));
+}
+
+function extractPlainText(property: any): string | undefined {
+  if (!property) return undefined;
+  if (Array.isArray(property.title)) {
+    return (
+      property.title
+        .map((item: { plain_text?: string }) => item.plain_text ?? '')
+        .join('')
+        .trim() || undefined
+    );
+  }
+  if (Array.isArray(property.rich_text)) {
+    return (
+      property.rich_text
+        .map((item: { plain_text?: string }) => item.plain_text ?? '')
+        .join('')
+        .trim() || undefined
+    );
+  }
+  if (typeof property === 'string') return property.trim();
+  return undefined;
+}

--- a/src/types/marshal.ts
+++ b/src/types/marshal.ts
@@ -1,0 +1,58 @@
+// src/types/marshal.ts
+
+import type { Member } from './members';
+
+export type MarshalRole = 'Marshal' | 'Umpire' | 'Static Umpire';
+
+export type MarshalShift =
+  | 'S1'
+  | 'S2'
+  | 'S3'
+  | 'S4'
+  | 'S5'
+  | 'U1'
+  | 'U2'
+  | 'U3'
+  | 'U4'
+  | 'Static A'
+  | 'Static B'
+  | 'Static C';
+
+export type MarshalDay = 'Wed' | 'Thu' | 'Fri' | 'Sat';
+
+export type MarshalLocation =
+  | 'Longbridges'
+  | 'Top Gut'
+  | 'Green 1 - Bottom Bunglines';
+
+export type MarshalEvent = 'Eights 2026' | 'Torpids 2026' | 'Other';
+
+export type ClashCrew = 'M4' | 'M3' | 'W3';
+
+export type MarshalPersonStatus =
+  | 'Open'
+  | 'Reserved'
+  | 'Maybe Available'
+  | 'Awaiting Approval'
+  | 'Confirmed'
+  | 'Not Available';
+
+export interface MarshalSlot {
+  id: string;
+  url: string;
+  name: string;
+  slotId?: number;
+  event?: MarshalEvent;
+  day?: MarshalDay;
+  role?: MarshalRole;
+  shift?: MarshalShift;
+  location?: MarshalLocation;
+  startTime: string;
+  endTime?: string;
+  isDatetime: boolean;
+  person?: Member;
+  personStatus: MarshalPersonStatus;
+  clashCrews: ClashCrew[];
+  notes?: string;
+  publish: boolean;
+}


### PR DESCRIPTION
## Summary
- New **Marshalling Signups** Notion DB (under the existing Marshalling/Umpires page) modelled on the SABC Outings DB. Populated with all 11 St Antony's commitments for Summer Eights 2026 (Wed 27 — Sat 30 May).
- New **/marshalling** route under `(app shell)` with a day-grouped slot table, click-to-open drawer for self-signup, and crew-clash warning chips.
- Three new API routes mirroring the test signup pattern: `get-marshals`, `assign-marshal`, `update-marshal-status`.
- New `MarshalIcon` + sidebar nav entry (between OURC Tests and Events).

## Notion DB
- Page: https://www.notion.so/36a80040a8fa807fa3e2c856dfd6834b
- DB ID fallback in `src/server/notion/marshals.ts`: `a7d958881fd84cbe92c80f3d659391fd`
- Override with env var `NOTION_MARSHALS_DB_ID` if needed.
- Schema: `Name`, `Slot ID` (auto), `Event`, `Day`, `Slot Time` (datetime range), `Role`, `Shift`, `Location`, `Person` (→ Membership), `Person Status`, `Clash Crews` (M4/M3/W3), `Notes`, `Publish`.

## Clash-flag logic
Each slot has a manually-set `Clash Crews` multi-select. A crew is flagged when the race time ± 1 hr overlaps the shift. M4 races at 15:15 (Wed–Fri) / 14:15 (Sat); W3 races at 16:45 / 15:45. M3 is pre-flagged where the captain has indicated a possible Div IV→III promotion.

## Signup flow
1. Member clicks a slot row → drawer opens.
2. Member picks themselves → status auto-flips to **Awaiting Approval** (unless already Confirmed/Reserved/Not Available).
3. Captain reviews → marks **Confirmed** in the drawer or directly in Notion.
4. Clearing the assignment resets status to **Open**.

## Test plan
- [ ] `npm run dev` and visit `/marshalling`
- [ ] Table renders with 11 published slots, grouped Wed → Sat
- [ ] Click a slot → drawer opens with details, notes, and (where applicable) crew clash banner
- [ ] Pick a member → row updates to show them with **Awaiting Approval**
- [ ] Click another status chip (e.g. **Confirmed**) → status updates immediately
- [ ] Click **Clear** → row returns to **Open** with no person
- [ ] Sidebar Marshalling entry highlights when on `/marshalling`
- [ ] Verify Notion DB rows reflect changes in real time

## Notes
- Desktop-first layout; the table uses a 6-column grid that overflows horizontally on narrow screens. Mobile pass can be a follow-up if needed before the event.
- The Saturday static umpire is modelled as **three rows** (Part A 10:15–13:15, Part B 13:15–16:15, Part C 16:15–18:10) — matches OURCs' "min 2 hrs per person" rule.
- `Publish` checkbox is checked on all 11 rows; the API filters server-side so any draft/test rows added later stay hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)