### PR TITLE
Marshalling: remove status, auto-confirm on signup, full crew names

### DIFF
--- a/src/app/(app shell)/marshalling/MarshalDrawer.tsx
+++ b/src/app/(app shell)/marshalling/MarshalDrawer.tsx
@@ -11,6 +11,7 @@ interface MarshalDrawerProps {
   isOpen: boolean;
   onClose: () => void;
   onChange: () => void;
+  onMembersChange?: () => void;
 }
 
 function formatTimeRange(start: string, end?: string) {
@@ -39,10 +40,12 @@ export default function MarshalDrawer({
   isOpen,
   onClose,
   onChange,
+  onMembersChange,
 }: MarshalDrawerProps) {
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(slot.person?.id ?? null);
   const [query, setQuery] = useState('');
   const [saving, setSaving] = useState(false);
+  const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -51,13 +54,24 @@ export default function MarshalDrawer({
     setError(null);
   }, [slot.id, slot.person?.id]);
 
+  const trimmedQuery = query.trim();
+
   const filteredMembers = useMemo(() => {
-    if (!query.trim()) return members;
-    const q = query.toLowerCase();
+    if (!trimmedQuery) return members;
+    const q = trimmedQuery.toLowerCase();
     return members.filter(
       (m) => m.name.toLowerCase().includes(q) || (m.email || '').toLowerCase().includes(q)
     );
-  }, [members, query]);
+  }, [members, trimmedQuery]);
+
+  const exactMatch = useMemo(
+    () =>
+      trimmedQuery &&
+      members.some((m) => m.name.toLowerCase() === trimmedQuery.toLowerCase()),
+    [members, trimmedQuery]
+  );
+
+  const canCreate = Boolean(trimmedQuery) && !exactMatch && !creating;
 
   async function saveAssignment(newMemberId: string | null) {
     setSaving(true);
@@ -81,6 +95,38 @@ export default function MarshalDrawer({
   async function handlePick(memberId: string | null) {
     setSelectedMemberId(memberId);
     await saveAssignment(memberId);
+  }
+
+  async function handleCreateAndAssign() {
+    const name = trimmedQuery;
+    if (!name) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const createRes = await fetch('/api/add-member', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, role: 'non-member' }),
+      });
+      if (!createRes.ok) {
+        const data = await createRes.json().catch(() => ({}));
+        throw new Error(data.error || `Failed to create member (HTTP ${createRes.status})`);
+      }
+      const created = await createRes.json();
+      const newId: string | undefined = created?.member?.id;
+      if (!newId) throw new Error('Member created but no ID returned');
+
+      // Refresh parent members list so this name is discoverable next time
+      onMembersChange?.();
+
+      // Assign to this slot
+      setSelectedMemberId(newId);
+      await saveAssignment(newId);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to add new member');
+    } finally {
+      setCreating(false);
+    }
   }
 
   return (
@@ -140,7 +186,7 @@ export default function MarshalDrawer({
             <>
               <input
                 type="search"
-                placeholder="Search members…"
+                placeholder="Search members or type a new name…"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 style={inputStyle}
@@ -163,7 +209,7 @@ export default function MarshalDrawer({
                       key={m.id}
                       type="button"
                       onClick={() => handlePick(m.id)}
-                      disabled={saving}
+                      disabled={saving || creating}
                       style={memberRowStyle}
                     >
                       <span style={{ fontWeight: 600 }}>{m.name}</span>
@@ -172,6 +218,21 @@ export default function MarshalDrawer({
                   ))
                 )}
               </div>
+              {canCreate && (
+                <button
+                  type="button"
+                  onClick={handleCreateAndAssign}
+                  disabled={saving || creating}
+                  style={createBtnStyle}
+                >
+                  + Add “{trimmedQuery}” as new member and sign up
+                </button>
+              )}
+              {creating && (
+                <p style={{ color: '#64748B', fontSize: '12px', margin: 0 }}>
+                  Creating member…
+                </p>
+              )}
             </>
           )}
         </section>
@@ -276,4 +337,17 @@ const clearBtnStyle: React.CSSProperties = {
   fontSize: '12px',
   fontWeight: 600,
   cursor: 'pointer',
+};
+
+const createBtnStyle: React.CSSProperties = {
+  padding: '10px 14px',
+  borderRadius: '8px',
+  border: '1px dashed #BFDBFE',
+  background: '#EFF6FF',
+  color: '#1D4ED8',
+  fontSize: '13px',
+  fontWeight: 600,
+  cursor: 'pointer',
+  fontFamily: 'Gilroy',
+  textAlign: 'left',
 };

--- a/src/app/(app shell)/marshalling/MarshalDrawer.tsx
+++ b/src/app/(app shell)/marshalling/MarshalDrawer.tsx
@@ -2,21 +2,8 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import Sheet from '@/components/ui/Sheet';
-import type {
-  ClashCrew,
-  MarshalPersonStatus,
-  MarshalSlot,
-} from '@/types/marshal';
+import type { ClashCrew, MarshalSlot } from '@/types/marshal';
 import type { Member } from '@/types/members';
-
-const STATUS_OPTIONS: MarshalPersonStatus[] = [
-  'Open',
-  'Reserved',
-  'Maybe Available',
-  'Awaiting Approval',
-  'Confirmed',
-  'Not Available',
-];
 
 interface MarshalDrawerProps {
   slot: MarshalSlot;
@@ -54,17 +41,15 @@ export default function MarshalDrawer({
   onChange,
 }: MarshalDrawerProps) {
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(slot.person?.id ?? null);
-  const [status, setStatus] = useState<MarshalPersonStatus>(slot.personStatus);
   const [query, setQuery] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     setSelectedMemberId(slot.person?.id ?? null);
-    setStatus(slot.personStatus);
     setQuery('');
     setError(null);
-  }, [slot.id, slot.person?.id, slot.personStatus]);
+  }, [slot.id, slot.person?.id]);
 
   const filteredMembers = useMemo(() => {
     if (!query.trim()) return members;
@@ -93,33 +78,9 @@ export default function MarshalDrawer({
     }
   }
 
-  async function saveStatus(newStatus: MarshalPersonStatus) {
-    setSaving(true);
-    setError(null);
-    try {
-      const res = await fetch('/api/update-marshal-status', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ slotId: slot.id, status: newStatus }),
-      });
-      const data = await res.json();
-      if (!data.success) throw new Error(data.error || 'Failed to update');
-      onChange();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Unknown error');
-    } finally {
-      setSaving(false);
-    }
-  }
-
   async function handlePick(memberId: string | null) {
     setSelectedMemberId(memberId);
     await saveAssignment(memberId);
-  }
-
-  async function handleStatusChange(next: MarshalPersonStatus) {
-    setStatus(next);
-    await saveStatus(next);
   }
 
   return (
@@ -158,13 +119,13 @@ export default function MarshalDrawer({
                 alignItems: 'center',
                 justifyContent: 'space-between',
                 padding: '10px 14px',
-                background: '#EEF6FF',
-                border: '1px solid #BFDBFE',
+                background: '#DCFCE7',
+                border: '1px solid #86EFAC',
                 borderRadius: '8px',
               }}
             >
-              <span style={{ color: '#161736', fontWeight: 600 }}>
-                {members.find((m) => m.id === selectedMemberId)?.name ?? 'Selected'}
+              <span style={{ color: '#15803D', fontWeight: 600 }}>
+                ✓ {members.find((m) => m.id === selectedMemberId)?.name ?? 'Confirmed'}
               </span>
               <button
                 type="button"
@@ -186,7 +147,7 @@ export default function MarshalDrawer({
               />
               <div
                 style={{
-                  maxHeight: '240px',
+                  maxHeight: '320px',
                   overflowY: 'auto',
                   border: '1px solid #DFE5F1',
                   borderRadius: '8px',
@@ -213,27 +174,6 @@ export default function MarshalDrawer({
               </div>
             </>
           )}
-        </section>
-
-        <section style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-          <label style={labelStyle}>Status</label>
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
-            {STATUS_OPTIONS.map((opt) => (
-              <button
-                key={opt}
-                type="button"
-                disabled={saving}
-                onClick={() => handleStatusChange(opt)}
-                style={{
-                  ...chipBtnStyle,
-                  background: status === opt ? '#0177FB' : '#F1F5F9',
-                  color: status === opt ? '#FFF' : '#475569',
-                }}
-              >
-                {opt}
-              </button>
-            ))}
-          </div>
         </section>
 
         {error && (
@@ -331,19 +271,9 @@ const clearBtnStyle: React.CSSProperties = {
   padding: '4px 10px',
   borderRadius: '6px',
   background: '#FFF',
-  border: '1px solid #BFDBFE',
-  color: '#1D4ED8',
+  border: '1px solid #86EFAC',
+  color: '#15803D',
   fontSize: '12px',
   fontWeight: 600,
   cursor: 'pointer',
-};
-
-const chipBtnStyle: React.CSSProperties = {
-  padding: '6px 12px',
-  borderRadius: '999px',
-  border: 'none',
-  fontSize: '13px',
-  fontWeight: 600,
-  cursor: 'pointer',
-  fontFamily: 'Gilroy',
 };

--- a/src/app/(app shell)/marshalling/MarshallingPageClient.tsx
+++ b/src/app/(app shell)/marshalling/MarshallingPageClient.tsx
@@ -183,6 +183,7 @@ export default function MarshallingPageClient() {
           isOpen={!!selectedSlot}
           onClose={() => setSelectedId(null)}
           onChange={() => loadSlots()}
+          onMembersChange={() => loadMembers()}
         />
       )}
     </main>

--- a/src/app/(app shell)/marshalling/MarshallingPageClient.tsx
+++ b/src/app/(app shell)/marshalling/MarshallingPageClient.tsx
@@ -1,11 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import type {
-  MarshalDay,
-  MarshalPersonStatus,
-  MarshalSlot,
-} from '@/types/marshal';
+import type { MarshalDay, MarshalSlot } from '@/types/marshal';
 import type { Member } from '@/types/members';
 import MarshalDrawer from './MarshalDrawer';
 
@@ -22,15 +18,6 @@ const ROLE_COLORS: Record<string, string> = {
   Marshal: '#0177FB',
   Umpire: '#F97316',
   'Static Umpire': '#A855F7',
-};
-
-const STATUS_COLORS: Record<MarshalPersonStatus, { bg: string; fg: string }> = {
-  Open: { bg: '#F1F5F9', fg: '#64748B' },
-  Reserved: { bg: '#E2E8F0', fg: '#475569' },
-  'Maybe Available': { bg: '#DBEAFE', fg: '#1D4ED8' },
-  'Awaiting Approval': { bg: '#FEF3C7', fg: '#B45309' },
-  Confirmed: { bg: '#DCFCE7', fg: '#15803D' },
-  'Not Available': { bg: '#FEE2E2', fg: '#B91C1C' },
 };
 
 function formatTimeRange(start: string, end?: string) {
@@ -101,9 +88,8 @@ export default function MarshallingPageClient() {
 
   const counts = useMemo(() => {
     const total = slots.length;
-    const filled = slots.filter((s) => s.person && s.personStatus !== 'Open').length;
-    const confirmed = slots.filter((s) => s.personStatus === 'Confirmed').length;
-    return { total, filled, confirmed };
+    const filled = slots.filter((s) => Boolean(s.person)).length;
+    return { total, filled };
   }, [slots]);
 
   return (
@@ -130,9 +116,9 @@ export default function MarshallingPageClient() {
           Marshalling & Umpires
         </h1>
         <p style={{ color: '#425466', fontFamily: 'Gilroy', fontSize: '16px', margin: 0 }}>
-          St Antony&apos;s commitments for Summer Eights 2026 (27–30 May). Click a slot to sign up.
-          Slots tagged with a crew warning cannot be taken by rowers in that crew (race time ± 1 hr
-          falls within the shift).
+          St Antony&apos;s commitments for Summer Eights 2026 (27–30 May). Click a slot to sign up
+          — your name confirms the slot. Crew warnings indicate rowers who cannot take the slot
+          (race time ± 1 hr overlaps the shift).
         </p>
         <p
           style={{
@@ -142,9 +128,7 @@ export default function MarshallingPageClient() {
             margin: '4px 0 0 0',
           }}
         >
-          {loading
-            ? 'Loading…'
-            : `${counts.filled} / ${counts.total} filled · ${counts.confirmed} confirmed`}
+          {loading ? 'Loading…' : `${counts.filled} / ${counts.total} filled`}
         </p>
       </header>
 
@@ -206,14 +190,14 @@ export default function MarshallingPageClient() {
 }
 
 function SlotRow({ slot, onClick }: { slot: MarshalSlot; onClick: () => void }) {
-  const statusColors = STATUS_COLORS[slot.personStatus] ?? STATUS_COLORS.Open;
   const roleColor = slot.role ? ROLE_COLORS[slot.role] : '#0177FB';
+  const filled = Boolean(slot.person);
   return (
     <button
       onClick={onClick}
       style={{
         display: 'grid',
-        gridTemplateColumns: '140px 170px minmax(180px, 1fr) minmax(160px, 1fr) 160px minmax(160px, 1fr)',
+        gridTemplateColumns: '140px 170px minmax(180px, 1fr) minmax(160px, 1fr) minmax(160px, 1fr)',
         gap: '12px',
         alignItems: 'center',
         background: '#FFF',
@@ -246,22 +230,24 @@ function SlotRow({ slot, onClick }: { slot: MarshalSlot; onClick: () => void }) 
         {slot.role ?? '—'} · {slot.shift ?? ''}
       </span>
       <span style={{ color: '#425466', fontSize: '13px' }}>{slot.location ?? '—'}</span>
-      <span style={{ color: '#161736' }}>
-        {slot.person ? slot.person.name : <em style={{ color: '#94A3B8' }}>Unfilled</em>}
-      </span>
       <span
         style={{
           display: 'inline-flex',
-          padding: '4px 10px',
-          borderRadius: '999px',
-          background: statusColors.bg,
-          color: statusColors.fg,
-          fontSize: '12px',
-          fontWeight: 600,
-          width: 'fit-content',
+          alignItems: 'center',
+          gap: '8px',
+          color: filled ? '#15803D' : '#94A3B8',
+          fontWeight: filled ? 600 : 400,
+          fontStyle: filled ? 'normal' : 'italic',
         }}
       >
-        {slot.personStatus}
+        {filled ? (
+          <>
+            <span aria-hidden>✓</span>
+            {slot.person!.name}
+          </>
+        ) : (
+          'Unfilled'
+        )}
       </span>
       <span style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', alignItems: 'center' }}>
         {slot.clashCrews.length > 0 ? (

--- a/src/app/api/assign-marshal/route.ts
+++ b/src/app/api/assign-marshal/route.ts
@@ -22,15 +22,8 @@ export async function POST(request: NextRequest) {
 
     if (memberId) {
       properties['Person'] = { relation: [{ id: memberId }] };
-
-      const slotPage = await notion.pages.retrieve({ page_id: slotId });
-      const current =
-        (slotPage as { properties?: Record<string, { select?: { name?: string } }> })
-          .properties?.['Person Status']?.select?.name;
-      const skipSet = current && ['Confirmed', 'Reserved', 'Not Available'].includes(current);
-      if (!skipSet) {
-        properties['Person Status'] = { select: { name: 'Awaiting Approval' } };
-      }
+      // Signup = confirmed. No intermediate approval step.
+      properties['Person Status'] = { select: { name: 'Confirmed' } };
     } else {
       properties['Person'] = { relation: [] };
       properties['Person Status'] = { select: { name: 'Open' } };

--- a/src/types/marshal.ts
+++ b/src/types/marshal.ts
@@ -27,7 +27,7 @@ export type MarshalLocation =
 
 export type MarshalEvent = 'Eights 2026' | 'Torpids 2026' | 'Other';
 
-export type ClashCrew = 'M4' | 'M3' | 'W3';
+export type ClashCrew = 'Men Div 4' | 'Men Div 3' | 'Women Div 3';
 
 export type MarshalPersonStatus =
   | 'Open'


### PR DESCRIPTION
## Summary
Two follow-ups to PR #67:

### 1. Remove manual Status control — signup = confirmed
- Drawer no longer shows status chips
- `assign-marshal` API now sets `Person Status` to **Confirmed** when a member is assigned, **Open** when cleared
- Slot row simplified: shows ✓ + name in green when filled, italic "Unfilled" when not
- Status column removed from the row layout
- (Status field still lives in Notion for backend use — captains can still set Reserved / Not Available there if needed)

### 2. Rename clash crew labels
- `M4` → **Men Div 4**
- `M3` → **Men Div 3**
- `W3` → **Women Div 3**

Applied in both Notion (new multi-select options added; all 7 affected rows re-tagged) and frontend types.

## Test plan
- [ ] `/marshalling` loads — header reads \"N / 11 filled\" (no more 'confirmed' subcount)
- [ ] Click a slot → drawer shows details + (where applicable) clash warning with full crew names
- [ ] Pick a member → slot shows ✓ name in green immediately; Notion row goes to **Confirmed**
- [ ] Click **Clear** → slot returns to italic 'Unfilled'; Notion status returns to **Open**
- [ ] Crew clash chips on rows + drawer banner display 'Men Div 4' etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)