### PR TITLE
Fix: marshalling page showing stale data after assign/clear

### DIFF
--- a/src/app/api/get-marshals/route.ts
+++ b/src/app/api/get-marshals/route.ts
@@ -3,7 +3,10 @@ import { NextResponse } from 'next/server';
 import { getMarshals } from '@/server/notion/marshals';
 import { startTiming, createServerTiming } from '@/server/timing';
 
-export const revalidate = 30;
+// Always read Notion fresh — the page is signup-driven and stale data
+// (e.g. after assign/clear or an edit made directly in Notion) confuses
+// captains who expect the table to reflect reality immediately.
+export const dynamic = 'force-dynamic';
 
 export async function GET() {
   const start = startTiming();


### PR DESCRIPTION
## Bug
End-to-end test on prod revealed the marshalling page serves stale data after every assign/clear and never reflects Notion edits in real time.

Reproduction:
1. POST /api/assign-marshal with a memberId → Notion updates correctly
2. Immediately GET /api/get-marshals → returns the *prior* cached payload
3. Wait 35s, clear via API → next GET returns the *assigned* state (not cleared)

## Cause
\`export const revalidate = 30\` on the Route Handler enables ISR. The client's \`fetch(..., { cache: 'no-store' })\` only bypasses browser/CDN cache, not the server-side Route Handler cache. The drawer's optimistic local state hides this most of the time, but a page refresh shows stale data and external Notion edits never appear.

## Fix
Swap \`revalidate = 30\` → \`dynamic = 'force-dynamic'\` so each request reads Notion fresh. One-line change; no other side effects (Server-Timing header still logged).

## Test plan
- [ ] Vercel preview deploys cleanly
- [ ] Repeat the assign/clear round-trip → both Notion and \`/api/get-marshals\` reflect the change immediately
- [ ] Hard-refresh /marshalling after a Notion-side edit → page reflects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)