### PR TITLE
Make /marshalling fully responsive on mobile

### DIFF
--- a/src/app/(app shell)/marshalling/MarshalDrawer.tsx
+++ b/src/app/(app shell)/marshalling/MarshalDrawer.tsx
@@ -34,6 +34,17 @@ function formatDate(start: string) {
   });
 }
 
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 768);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+  return isMobile;
+}
+
 export default function MarshalDrawer({
   slot,
   members,
@@ -47,6 +58,7 @@ export default function MarshalDrawer({
   const [saving, setSaving] = useState(false);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     setSelectedMemberId(slot.person?.id ?? null);
@@ -116,10 +128,7 @@ export default function MarshalDrawer({
       const newId: string | undefined = created?.member?.id;
       if (!newId) throw new Error('Member created but no ID returned');
 
-      // Refresh parent members list so this name is discoverable next time
       onMembersChange?.();
-
-      // Assign to this slot
       setSelectedMemberId(newId);
       await saveAssignment(newId);
     } catch (e) {
@@ -132,7 +141,13 @@ export default function MarshalDrawer({
   return (
     <Sheet isOpen={isOpen} onClose={onClose} title={slot.name}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
-        <section style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px' }}>
+        <section
+          style={{
+            display: 'grid',
+            gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr',
+            gap: isMobile ? '12px' : '16px',
+          }}
+        >
           <Detail label="Date" value={formatDate(slot.startTime)} />
           <Detail label="Time" value={formatTimeRange(slot.startTime, slot.endTime)} />
           <Detail label="Role" value={`${slot.role ?? '—'} · ${slot.shift ?? ''}`} />
@@ -164,13 +179,22 @@ export default function MarshalDrawer({
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'space-between',
-                padding: '10px 14px',
+                padding: '12px 14px',
                 background: '#DCFCE7',
                 border: '1px solid #86EFAC',
                 borderRadius: '8px',
+                gap: '12px',
               }}
             >
-              <span style={{ color: '#15803D', fontWeight: 600 }}>
+              <span
+                style={{
+                  color: '#15803D',
+                  fontWeight: 600,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
                 ✓ {members.find((m) => m.id === selectedMemberId)?.name ?? 'Confirmed'}
               </span>
               <button
@@ -189,14 +213,19 @@ export default function MarshalDrawer({
                 placeholder="Search members or type a new name…"
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
-                style={inputStyle}
+                style={{
+                  ...inputStyle,
+                  padding: isMobile ? '12px 12px' : '10px 12px',
+                  fontSize: isMobile ? '16px' : '14px', // 16px prevents iOS auto-zoom
+                }}
               />
               <div
                 style={{
-                  maxHeight: '320px',
+                  maxHeight: isMobile ? '280px' : '320px',
                   overflowY: 'auto',
                   border: '1px solid #DFE5F1',
                   borderRadius: '8px',
+                  WebkitOverflowScrolling: 'touch',
                 }}
               >
                 {filteredMembers.length === 0 ? (
@@ -210,7 +239,11 @@ export default function MarshalDrawer({
                       type="button"
                       onClick={() => handlePick(m.id)}
                       disabled={saving || creating}
-                      style={memberRowStyle}
+                      style={{
+                        ...memberRowStyle,
+                        padding: isMobile ? '14px' : '10px 14px',
+                        minHeight: isMobile ? '48px' : 'auto',
+                      }}
                     >
                       <span style={{ fontWeight: 600 }}>{m.name}</span>
                       <span style={{ color: '#94A3B8', fontSize: '12px' }}>{m.memberType}</span>
@@ -223,7 +256,11 @@ export default function MarshalDrawer({
                   type="button"
                   onClick={handleCreateAndAssign}
                   disabled={saving || creating}
-                  style={createBtnStyle}
+                  style={{
+                    ...createBtnStyle,
+                    padding: isMobile ? '14px' : '10px 14px',
+                    minHeight: isMobile ? '48px' : 'auto',
+                  }}
                 >
                   + Add “{trimmedQuery}” as new member and sign up
                 </button>
@@ -305,11 +342,11 @@ const labelStyle: React.CSSProperties = {
 };
 
 const inputStyle: React.CSSProperties = {
-  padding: '10px 12px',
   border: '1px solid #DFE5F1',
   borderRadius: '8px',
-  fontSize: '14px',
   fontFamily: 'Gilroy',
+  width: '100%',
+  boxSizing: 'border-box',
 };
 
 const memberRowStyle: React.CSSProperties = {
@@ -317,7 +354,6 @@ const memberRowStyle: React.CSSProperties = {
   justifyContent: 'space-between',
   alignItems: 'center',
   width: '100%',
-  padding: '10px 14px',
   background: '#FFF',
   border: 'none',
   borderBottom: '1px solid #F1F5F9',
@@ -329,7 +365,7 @@ const memberRowStyle: React.CSSProperties = {
 };
 
 const clearBtnStyle: React.CSSProperties = {
-  padding: '4px 10px',
+  padding: '6px 12px',
   borderRadius: '6px',
   background: '#FFF',
   border: '1px solid #86EFAC',
@@ -337,10 +373,10 @@ const clearBtnStyle: React.CSSProperties = {
   fontSize: '12px',
   fontWeight: 600,
   cursor: 'pointer',
+  flexShrink: 0,
 };
 
 const createBtnStyle: React.CSSProperties = {
-  padding: '10px 14px',
   borderRadius: '8px',
   border: '1px dashed #BFDBFE',
   background: '#EFF6FF',
@@ -350,4 +386,5 @@ const createBtnStyle: React.CSSProperties = {
   cursor: 'pointer',
   fontFamily: 'Gilroy',
   textAlign: 'left',
+  width: '100%',
 };

--- a/src/app/(app shell)/marshalling/MarshallingPageClient.tsx
+++ b/src/app/(app shell)/marshalling/MarshallingPageClient.tsx
@@ -31,12 +31,24 @@ function formatTimeRange(start: string, end?: string) {
   return `${fmt(new Date(start))}–${fmt(new Date(end))}`;
 }
 
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 768);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+  return isMobile;
+}
+
 export default function MarshallingPageClient() {
   const [slots, setSlots] = useState<MarshalSlot[]>([]);
   const [members, setMembers] = useState<Member[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const isMobile = useIsMobile();
 
   const loadSlots = useCallback(async () => {
     setLoading(true);
@@ -97,10 +109,12 @@ export default function MarshallingPageClient() {
       style={{
         display: 'flex',
         flexDirection: 'column',
-        gap: '32px',
-        padding: '32px',
+        gap: isMobile ? '24px' : '32px',
+        padding: isMobile ? '16px' : '32px',
         boxSizing: 'border-box',
         width: '100%',
+        maxWidth: '100%',
+        overflowX: 'hidden',
       }}
     >
       <header style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
@@ -108,15 +122,23 @@ export default function MarshallingPageClient() {
           style={{
             color: '#161736',
             fontFamily: 'Gilroy',
-            fontSize: '32px',
+            fontSize: isMobile ? '24px' : '32px',
             fontWeight: 800,
             margin: 0,
           }}
         >
           Marshalling & Umpires
         </h1>
-        <p style={{ color: '#425466', fontFamily: 'Gilroy', fontSize: '16px', margin: 0 }}>
-          St Antony&apos;s commitments for Summer Eights 2026 (27–30 May). Click a slot to sign up
+        <p
+          style={{
+            color: '#425466',
+            fontFamily: 'Gilroy',
+            fontSize: isMobile ? '14px' : '16px',
+            margin: 0,
+            lineHeight: 1.5,
+          }}
+        >
+          St Antony&apos;s commitments for Summer Eights 2026 (27–30 May). Tap a slot to sign up
           — your name confirms the slot. Crew warnings indicate rowers who cannot take the slot
           (race time ± 1 hr overlaps the shift).
         </p>
@@ -154,7 +176,7 @@ export default function MarshallingPageClient() {
               style={{
                 color: '#161736',
                 fontFamily: 'Gilroy',
-                fontSize: '20px',
+                fontSize: isMobile ? '17px' : '20px',
                 fontWeight: 700,
                 margin: 0,
                 paddingBottom: '4px',
@@ -168,6 +190,7 @@ export default function MarshallingPageClient() {
                 <SlotRow
                   key={slot.id}
                   slot={slot}
+                  isMobile={isMobile}
                   onClick={() => setSelectedId(slot.id)}
                 />
               ))}
@@ -190,88 +213,146 @@ export default function MarshallingPageClient() {
   );
 }
 
-function SlotRow({ slot, onClick }: { slot: MarshalSlot; onClick: () => void }) {
+function SlotRow({
+  slot,
+  isMobile,
+  onClick,
+}: {
+  slot: MarshalSlot;
+  isMobile: boolean;
+  onClick: () => void;
+}) {
   const roleColor = slot.role ? ROLE_COLORS[slot.role] : '#0177FB';
   const filled = Boolean(slot.person);
+
+  const personEl = filled ? (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '8px',
+        color: '#15803D',
+        fontWeight: 600,
+      }}
+    >
+      <span aria-hidden>✓</span>
+      {slot.person!.name}
+    </span>
+  ) : (
+    <span style={{ color: '#94A3B8', fontStyle: 'italic' }}>Unfilled</span>
+  );
+
+  const clashEl =
+    slot.clashCrews.length > 0 ? (
+      <span style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', alignItems: 'center' }}>
+        {slot.clashCrews.map((c) => (
+          <span
+            key={c}
+            title="Rowers in this crew cannot take this slot"
+            style={{
+              padding: '2px 8px',
+              borderRadius: '999px',
+              background: '#FEE2E2',
+              color: '#B91C1C',
+              fontSize: '11px',
+              fontWeight: 700,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            ⚠ {c}
+          </span>
+        ))}
+      </span>
+    ) : (
+      <span style={{ color: '#94A3B8', fontSize: '12px' }}>No clashes</span>
+    );
+
+  const roleChip = (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: '4px 10px',
+        borderRadius: '999px',
+        background: `${roleColor}15`,
+        color: roleColor,
+        fontWeight: 600,
+        fontSize: '12px',
+        width: 'fit-content',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {slot.role ?? '—'} · {slot.shift ?? ''}
+    </span>
+  );
+
+  const baseBtnStyle: React.CSSProperties = {
+    background: '#FFF',
+    border: '1px solid #DFE5F1',
+    borderRadius: '12px',
+    textAlign: 'left',
+    cursor: 'pointer',
+    boxShadow: '0 1px 2px rgba(0,0,0,0.02)',
+    fontFamily: 'Gilroy',
+    color: '#161736',
+    fontSize: '14px',
+    width: '100%',
+  };
+
+  if (isMobile) {
+    return (
+      <button
+        onClick={onClick}
+        style={{
+          ...baseBtnStyle,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '10px',
+          padding: '14px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: '8px',
+            width: '100%',
+          }}
+        >
+          <span style={{ fontWeight: 700, fontSize: '15px' }}>
+            {formatTimeRange(slot.startTime, slot.endTime)}
+          </span>
+          {roleChip}
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '13px' }}>
+          <span style={{ color: '#64748B' }}>{slot.location ?? '—'}</span>
+          <span>{personEl}</span>
+        </div>
+        <div>{clashEl}</div>
+      </button>
+    );
+  }
+
   return (
     <button
       onClick={onClick}
       style={{
+        ...baseBtnStyle,
         display: 'grid',
-        gridTemplateColumns: '140px 170px minmax(180px, 1fr) minmax(160px, 1fr) minmax(160px, 1fr)',
+        gridTemplateColumns:
+          '140px 170px minmax(180px, 1fr) minmax(160px, 1fr) minmax(160px, 1fr)',
         gap: '12px',
         alignItems: 'center',
-        background: '#FFF',
-        border: '1px solid #DFE5F1',
-        borderRadius: '12px',
         padding: '14px 16px',
-        textAlign: 'left',
-        cursor: 'pointer',
-        boxShadow: '0 1px 2px rgba(0,0,0,0.02)',
-        fontFamily: 'Gilroy',
-        color: '#161736',
-        fontSize: '14px',
       }}
     >
       <span style={{ fontWeight: 600 }}>{formatTimeRange(slot.startTime, slot.endTime)}</span>
-      <span
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: '6px',
-          padding: '4px 10px',
-          borderRadius: '999px',
-          background: `${roleColor}15`,
-          color: roleColor,
-          fontWeight: 600,
-          fontSize: '12px',
-          width: 'fit-content',
-        }}
-      >
-        {slot.role ?? '—'} · {slot.shift ?? ''}
-      </span>
+      {roleChip}
       <span style={{ color: '#425466', fontSize: '13px' }}>{slot.location ?? '—'}</span>
-      <span
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: '8px',
-          color: filled ? '#15803D' : '#94A3B8',
-          fontWeight: filled ? 600 : 400,
-          fontStyle: filled ? 'normal' : 'italic',
-        }}
-      >
-        {filled ? (
-          <>
-            <span aria-hidden>✓</span>
-            {slot.person!.name}
-          </>
-        ) : (
-          'Unfilled'
-        )}
-      </span>
-      <span style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', alignItems: 'center' }}>
-        {slot.clashCrews.length > 0 ? (
-          slot.clashCrews.map((c) => (
-            <span
-              key={c}
-              title="Rowers in this crew cannot take this slot"
-              style={{
-                padding: '2px 8px',
-                borderRadius: '999px',
-                background: '#FEE2E2',
-                color: '#B91C1C',
-                fontSize: '11px',
-                fontWeight: 700,
-              }}
-            >
-              ⚠ {c}
-            </span>
-          ))
-        ) : (
-          <span style={{ color: '#94A3B8', fontSize: '12px' }}>No clashes</span>
-        )}
-      </span>
+      <span>{personEl}</span>
+      <span>{clashEl}</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
Mobile pass on /marshalling — desktop layout collapsed to a useful phone layout.

### Changes
- **Slot rows on mobile**: stacked card instead of 5-col grid. Top row = time + role chip; middle = location, then person; bottom = clash chips.
- **Header**: 24px (was 32) on mobile, padding 16px (was 32).
- **Drawer details grid**: collapses to 1 column under 768px.
- **Member list rows**: 48px touch target with 14px padding on mobile.
- **Search input**: 16px font-size on mobile to prevent iOS auto-zoom.
- **Member list**: `-webkit-overflow-scrolling: touch` for momentum scroll.
- Page wrapper now has \`overflow-x: hidden\` to defensively prevent the body from horizontal scroll if a label wraps oddly.

### Test plan
- [ ] Vercel preview renders without horizontal scroll at 375 / 390 / 414px widths
- [ ] Tap a slot — drawer opens correctly (Sheet already handles mobile sizing — full width, 80px top offset)
- [ ] Search input does not zoom in on iOS Safari
- [ ] Member list scrolls smoothly with momentum
- [ ] Add new member CTA wraps within card width

🤖 Generated with [Claude Code](https://claude.com/claude-code)